### PR TITLE
Use dask for PV time-series

### DIFF
--- a/atlite/pv/irradiation.py
+++ b/atlite/pv/irradiation.py
@@ -118,14 +118,14 @@ def _albedo(ds, influx):
 
 def TiltedGroundIrrad(ds, solar_position, surface_orientation, influx):
     surface_slope = surface_orientation['slope']
-    ground_t = influx * _albedo(ds, influx) * (1.0 - np.cos(surface_slope)) / 2.0
+    ground_t = influx * _albedo(ds, influx) * (1 - np.cos(surface_slope)) / 2
     return ground_t.rename('ground tilted')
 
-def TiltedIrradiation(ds, solar_position, surface_orientation, trigon_model, clearsky_model, altitude_threshold=1.):
+def TiltedIrradiation(ds, solar_position, surface_orientation, trigon_model, clearsky_model, altitude_threshold=1., dtype=np.float32):
 
     influx_toa = solar_position['atmospheric insolation']
     def clip(influx, influx_max):
-        return influx.clip(min=0., max=influx_max.transpose(*influx.dims))
+        return influx.clip(min=0, max=influx_max.transpose(*influx.dims))
 
     if 'influx' in ds:
         influx = clip(ds['influx'], influx_toa)
@@ -143,10 +143,10 @@ def TiltedIrradiation(ds, solar_position, surface_orientation, trigon_model, cle
 
         influx = direct + diffuse
         direct_t = k * direct
-        diffuse_t = ((1. + cos_surface_slope) / 2. * diffuse +
-                    _albedo(ds, influx) * influx * ((1. - cos_surface_slope) / 2.))
+        diffuse_t = ((dtype(1) + cos_surface_slope) / dtype(2) * diffuse +
+                     _albedo(ds, influx) * influx * ((dtype(1) - cos_surface_slope) / dtype(2)))
 
-        total_t = direct_t.fillna(0.) + diffuse_t.fillna(0.)
+        total_t = direct_t.fillna(0) + diffuse_t.fillna(0)
     else:
         diffuse_t = TiltedDiffuseIrrad(ds, solar_position, surface_orientation, direct, diffuse)
         direct_t = TiltedDirectIrrad(solar_position, surface_orientation, direct)

--- a/atlite/pv/irradiation.py
+++ b/atlite/pv/irradiation.py
@@ -91,7 +91,7 @@ def TiltedDiffuseIrrad(ds, solar_position, surface_orientation, direct, diffuse)
             logger.warn('diffuse_t exhibits negative values above altitude threshold.')
 
     with np.errstate(invalid='ignore'):
-        diffuse_t.clip(min=0.).fillna(0.)
+        diffuse_t = diffuse_t.clip(min=0.).fillna(0.)
 
     return diffuse_t.rename('diffuse tilted')
 

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -90,7 +90,7 @@ def SurfaceOrientation(ds, solar_position, orientation):
     # fixup incidence angle: if the panel is badly oriented and the sun shines
     # on the back of the panel (incidence angle > 90degree), the irradiation
     # would be negative instead of 0; this is prevented here.
-    cosincidence.values[cosincidence.values < 0.] = 0.
+    cosincidence = cosincidence.clip(min=0.)
 
     return xr.Dataset({'cosincidence': cosincidence,
                        'slope': surface_slope,

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -34,8 +34,7 @@ def _power_huld(irradiance, t_amb, pc):
                      pc['k_5'] * (np.log(G_)) ** 2) +
                pc['k_6'] * (T_ ** 2))
 
-        eff = eff.fillna(0.)
-        eff.values[eff.values < 0] = 0.  # Also make sure efficiency can't be negative
+        eff = eff.clip(min=0.).fillna(0.) # Make sure efficiency can't be negative
 
     return G_ * eff * pc.get('inverter_efficiency', 1.)
 
@@ -60,7 +59,7 @@ def _power_bofinger(irradiance, t_amb, pc):
 
     capacity = (pc['A'] + pc['B'] * 1000. + pc['C'] * np.log(1000.))*1e3
     power = irradiance * eta * (pc.get('inverter_efficiency', 1.) / capacity)
-    power.values[irradiance.transpose(*irradiance.dims).values < pc['threshold']] = 0.
+    power = power.where(irradiance >= pc['threshold'], 0.)
 
     return power.rename('AC power')
 

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-def SolarPosition(ds):
+def SolarPosition(ds, dtype=np.float32):
     """
     Compute solar azimuth and altitude
 
@@ -39,31 +39,33 @@ def SolarPosition(ds):
     t = ds.indexes['time']
     n = xr.DataArray(t.to_julian_date(), [ds.indexes['time']]) - 2451545.0
 
+    time = ds['time']
+
     L = 280.460 + 0.9856474 * n # mean longitude (deg)
     g = np.deg2rad(357.528 + 0.9856003 * n) # mean anomaly (rad)
     l = np.deg2rad(L + 1.915 * np.sin(g) + 0.020 * np.sin(2*g)) # ecliptic long. (rad)
     ep = np.deg2rad(23.439 - 4e-7 * n) # obliquity of the ecliptic (rad)
 
     ra = np.arctan2(np.cos(ep) * np.sin(l), np.cos(l)) # right ascencion (rad)
-    lmst = (6.697375 + (ds['time.hour'] + ds['time.minute'] / 60.0) +
-            0.0657098242 * n) * 15. + ds['lon'] # local mean sidereal time (deg)
-    h = (np.deg2rad(lmst) - ra + np.pi) % (2*np.pi) - np.pi # hour angle (rad)
+    lmst = ((6.697375 + (time.dt.hour + time.dt.minute / 60.0) +
+            0.0657098242 * n) * 15.).astype(dtype) + ds['lon'] # local mean sidereal time (deg)
+    h = ((np.deg2rad(lmst) - ra + np.pi) % (2*np.pi) - np.pi).astype(dtype) # hour angle (rad)
 
-    dec = np.arcsin(np.sin(ep) * np.sin(l))            # declination (rad)
+    dec = np.arcsin(np.sin(ep) * np.sin(l)).astype(dtype)            # declination (rad)
 
     # alt and az from [2]
-    lat = np.deg2rad(ds['lat'])
+    lat = np.deg2rad(ds['lat']).astype(dtype)
     # Clip before arcsin to prevent values < -1. from rounding errors; can cause NaNs later
     alt = np.arcsin((np.sin(lat)*np.sin(dec) + np.cos(lat)*np.cos(dec)*np.cos(h)).clip(min=-1., max=1.)).rename('altitude')
 
     az = np.arccos(((np.sin(dec)*np.cos(lat) - np.cos(dec)*np.sin(lat)*np.cos(h))/np.cos(alt)).clip(min=-1., max=1.))
-    az = az.where(h <= 0, 2*np.pi - az).rename('azimuth')
+    az = az.where(h <= 0, dtype(2*np.pi) - az).rename('azimuth')
 
     if 'influx_toa' in ds:
-        atmospheric_insolation = ds['influx_toa'].rename('atmospheric insolation')
+        atmospheric_insolation = ds['influx_toa'].rename('atmospheric insolation').astype(dtype)
     else:
         # [3]
-        atmospheric_insolation = (1366.1 * (1+0.033*np.cos(g)) * np.sin(alt)).rename('atmospheric insolation')
+        atmospheric_insolation = (1366.1 * (1+0.033*np.cos(g)).astype(dtype) * np.sin(alt)).rename('atmospheric insolation')
 
     solar_position = xr.Dataset({da.name: da
                                  for da in [alt,

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -37,9 +37,13 @@ def SolarPosition(ds, dtype=np.float32):
     # up to h and dec from [1]
 
     t = ds.indexes['time']
-    n = xr.DataArray(t.to_julian_date(), [ds.indexes['time']]) - 2451545.0
+    n = xr.DataArray(t.to_julian_date(), [t]) - 2451545.0
 
     time = ds['time']
+
+    if 'time' in ds.chunks:
+        n = n.chunk(dict(time=ds.chunks['time']))
+        time = time.chunk(dict(time=ds.chunks['time']))
 
     L = 280.460 + 0.9856474 * n # mean longitude (deg)
     g = np.deg2rad(357.528 + 0.9856003 * n) # mean anomaly (rad)


### PR DESCRIPTION
`convert_pv` is the last hurdle to a full dask mode in atlite. Refer also to #30 .

This PR replaces all the inplace transformations with clip and where so they work in principle on dask.

Unfortunately dask fails to properly optimize the task graph (into something which should be linear in time), but instead thrashes memory until it dies even for more small cutouts.

I wasn't able today to find any working solution (not even in synchronuous mode it works sensibly).

For future reference, its very helpful to visualize and profile dask:
```python
import dask
from dask.diagnostics import Profiler, ResourceProfiler, CacheProfiler, visualize
from dask.callbacks import Callback
class PrintKeys(Callback):
    def _pretask(self, key, dask, state):
        """Print the key of every task as it's started"""
        print("Computing: {0}!".format(repr(key)))

panel = atlite.resource.get_solarpanelconfig("CSi")
orientation = atlite.pv.orientation.get_orientation({"slope": 30, "azimuth": 180})
solar = atlite.convert.convert_pv(cutout.data, panel, orientation)

store_task = solar.to_netcdf('test.nc', compute=False)
store_task_opt, = dask.optimize(store_task)
store_task_opt.visualize()
# or: store_task_opt.visualize(filename="graph.dot")
# and then look at it using xdot

with dask.config.set(num_workers=2), \
     Profiler() as profiler, \
     ResourceProfiler(0.5) as mem, \
     CacheProfiler() as cache, \
     PrintKeys():
        dask.compute(store_task)

# shows bokeh plots for the dask computation
visualize([profiler, mem, cache])
```

You might also want to look at intermediate values, starting from:
```python
from atlite.pv.solar_position import SolarPosition
from atlite.pv.irradiation import TiltedIrradiation
from atlite.pv.solar_panel_model import SolarPanelModel
from atlite.pv.orientation import get_orientation, SurfaceOrientation
ds = cutout.data.astype(np.float32)
solar_position = SolarPosition(ds)
surface_orientation = SurfaceOrientation(ds, solar_position, orientation)

irradiation = TiltedIrradiation(ds, solar_position, surface_orientation, trigon_model="simple",
                                clearsky_model="simple")

solar_panel = SolarPanelModel(ds, irradiation, panel)
```