### PR TITLE
utils: Correct error message for cutout migration.

### DIFF
--- a/atlite/utils.py
+++ b/atlite/utils.py
@@ -60,9 +60,9 @@ def migrate_from_cutout_directory(old_cutout_dir, name, cutout_fn, cutoutparams)
     with xr.open_dataset(old_cutout_dir / "meta.nc") as meta:
         newname = old_cutout_dir.parent / f"{name}.nc"
         module = meta.attrs["module"]
-        minX, maxX = meta.indexes['x'][[0, -1]]
-        minY, maxY = meta.indexes['y'][[0, -1]]
-        minT, maxT = meta.indexes['time'][[0, -1]].strftime("%Y-%m")
+        minX, maxX = meta.indexes['x'].sort_values()[[0, -1]]
+        minY, maxY = meta.indexes['y'].sort_values()[[0, -1]]
+        minT, maxT = meta.indexes['time'].sort_values()[[0, -1]].strftime("%Y-%m")
 
         logger.warning(textwrap.dedent(f"""
             Found an old-style directory-like cutout. It can manually be recreated using
@@ -82,7 +82,7 @@ def migrate_from_cutout_directory(old_cutout_dir, name, cutout_fn, cutoutparams)
             data.attrs.update(meta.attrs)
             logger.warning("Migration successful. You can save the cutout to a new file with `cutout.prepare()`")
         except xr.MergeError:
-            logger.warning("Automatic migration failed. Re-create the cutout with the command above!")
+            logger.exception("Automatic migration failed. Re-create the cutout with the command above!")
             raise
 
     data.attrs['prepared_features'] = list(sys.modules['atlite.datasets.' + data.attrs["module"]].features)

--- a/atlite/utils.py
+++ b/atlite/utils.py
@@ -60,9 +60,9 @@ def migrate_from_cutout_directory(old_cutout_dir, name, cutout_fn, cutoutparams)
     with xr.open_dataset(old_cutout_dir / "meta.nc") as meta:
         newname = old_cutout_dir.parent / f"{name}.nc"
         module = meta.attrs["module"]
-        minX, maxX = meta.indexes['x'].sort_values()[[0, -1]]
-        minY, maxY = meta.indexes['y'].sort_values()[[0, -1]]
-        minT, maxT = meta.indexes['time'].sort_values()[[0, -1]].strftime("%Y-%m")
+        minX, maxX = meta.indexes['x'][[0, -1]]
+        minY, maxY = sorted(meta.indexes['y'][[0, -1]])
+        minT, maxT = meta.indexes['time'][[0, -1]].strftime("%Y-%m")
 
         logger.warning(textwrap.dedent(f"""
             Found an old-style directory-like cutout. It can manually be recreated using


### PR DESCRIPTION
* On trying to automatically migrate an existing cutout, display the correct (new) order (min,max) for coordinates in the cutout recreation command.
* Use the logging.error(...) facilities to correctly categorise the MergeError incl. the stack trace.