### PR TITLE
convert: Fix heat demand hourshift for xarray 0.15.1

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -219,9 +219,9 @@ def soil_temperature(cutout, **params):
 def convert_heat_demand(ds, threshold, a, constant, hour_shift):
     #Temperature is in Kelvin; take daily average
     T = ds['temperature']
-    T.coords['time'].values += np.timedelta64(dt.timedelta(hours=hour_shift))
+    T = T.assign_coords(time=(T.coords['time'] + np.timedelta64(dt.timedelta(hours=hour_shift))))
 
-    T = ds['temperature'].resample(time="1D").mean(dim='time')
+    T = T.resample(time="1D").mean(dim='time')
     threshold += 273.15
     heat_demand = a*(threshold - T)
 


### PR DESCRIPTION
From xarray version 0.15.1, .values cannot be assigned. You should
use the .assign_coords() method instead.

See release notes for xarray 0.15.1 "breaking changes":

http://xarray.pydata.org/en/stable/whats-new.html#v0-15-1-23-mar-2020