### PR TITLE
Fix cutout creation with odd bounds (era5)

### DIFF
--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -51,8 +51,8 @@ def _add_height(ds):
 
 def _area(coords):
     # North, West, South, East. Default: global
-    x0, x1 = coords['x'].values[[0,-1]]
-    y0, y1 = coords['y'].values[[0,-1]]
+    x0, x1 = coords['x'].min().item(), coords['x'].max().item()
+    y0, y1 = coords['y'].min().item(), coords['y'].max().item()
     return [y1, x0, y0, x1]
 
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -49,9 +49,12 @@ def _add_height(ds):
     ds = ds.drop('z')
     return ds
 
-def _area(xs, ys):
+def _area(coords):
     # North, West, South, East. Default: global
-    return [ys.stop, xs.start, ys.start, xs.stop]
+    x0, x1 = coords['x'].values[[0,-1]]
+    y0, y1 = coords['y'].values[[0,-1]]
+    return [y1, x0, y0, x1]
+
 
 def _rename_and_clean_coords(ds, add_lon_lat=True):
     """Rename 'longitude' and 'latitude' columns to 'x' and 'y'
@@ -168,10 +171,10 @@ def get_data(coords, period, feature, sanitize=True, tmpdir=None, **creation_par
     assert tmpdir is not None
 
     retrieval_params = {'product': 'reanalysis-era5-single-levels',
-                        'area': _area(creation_parameters.pop('x'),
-                                      creation_parameters.pop('y')),
+                        'area': _area(coords),
                         'tmpdir': tmpdir,
                         'chunks': creation_parameters.pop('chunks', None)}
+
 
     if {'dx', 'dy'}.issubset(creation_parameters):
         retrieval_params['grid'] = [creation_parameters.pop('dx'), creation_parameters.pop('dy')]


### PR DESCRIPTION
Since the big PR for v0.2 is already super big, I do it this way. Probably this is a good procedure for the upcoming fixes.

## Content
Fix cutout creation for odd bounds with `era5`

closes #64 