### PR TITLE
fix era5 grid alignment

### DIFF
--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -13,6 +13,8 @@ import pandas as pd
 import numpy as np
 import xarray as xr
 from dask import delayed
+from ..gis import maybe_swap_spatial_dims
+
 
 import logging
 logger = logging.getLogger(__name__)
@@ -60,6 +62,7 @@ def _rename_and_clean_coords(ds, add_lon_lat=True):
     """
 
     ds = ds.rename({'longitude': 'x', 'latitude': 'y'})
+    ds = maybe_swap_spatial_dims(ds)
     if add_lon_lat:
         ds = ds.assign_coords(lon=ds.coords['x'], lat=ds.coords['y'])
     return ds
@@ -136,7 +139,8 @@ def sanitize_inflow(ds):
     return ds
 
 def get_data_temperature(retrieval_params):
-    ds = retrieve_data(variable=['2m_temperature', 'soil_temperature_level_4'], **retrieval_params)
+    ds = retrieve_data(variable=['2m_temperature', 'soil_temperature_level_4'],
+                       **retrieval_params)
 
     ds = _rename_and_clean_coords(ds)
     ds = ds.rename({'t2m': 'temperature', 'stl4': 'soil temperature'})


### PR DESCRIPTION
As discussed in #62 the grid alignment of era5 datasets when `module=sarah` is swapped for the y-axis. This fixes the alignment for all datasets produced by era5.

closes #62 