### PR TITLE
use shapely's strtree instead of rtree

### DIFF
--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -34,6 +34,7 @@ from .convert import (convert_and_aggregate, heat_demand, hydro, temperature,
                       wind, pv, runoff, solar_thermal, soil_temperature)
 from .gis import compute_indicatormatrix
 from .data import requires_coords, requires_windowed, cutout_prepare
+from .utils import CachedAttribute
 
 class Cutout:
 
@@ -219,18 +220,12 @@ class Cutout:
         xs, ys = np.meshgrid(self.coords["x"], self.coords["y"])
         return np.asarray((np.ravel(xs), np.ravel(ys))).T
 
-    _grid_cells_cache = None
-    @property
-    def grid_cells(self):
-        if self._grid_cells_cache is not None:
-            return self._grid_cells_cache
 
+    @CachedAttribute
+    def grid_cells(self):
         coords = self.grid_coordinates()
         span = (coords[self.shape[1]+1] - coords[0]) / 2
         grid_cells = [box(*c) for c in np.hstack((coords - span, coords + span))]
-
-        # Cache
-        self._grid_cells_cache = grid_cells
         return grid_cells
 
 

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -207,8 +207,7 @@ def cutout_prepare(cutout, features=None, freq=None, tmpdir=True, overwrite=Fals
 
             if not missing_features and not overwrite:
                 logger.info(f"All available features {cutout.available_features} have already been prepared, so nothing to do."
-                            f" Use `overwrite=True` to re-create {cutout.path.name} and"
-                            f" {cutout.path.with_suffix('.sindex.pickle').name}.")
+                            f" Use `overwrite=True` to re-create {cutout.path.name} .")
                 return
 
             ds = get_missing_data(cutout, missing_features, freq, tmpdir=tmpdir)
@@ -251,6 +250,3 @@ def cutout_prepare(cutout, features=None, freq=None, tmpdir=True, overwrite=Fals
     if not isinstance(prepared_features, list):
         cutout.data.attrs['prepared_features'] = [prepared_features]
 
-    # Save spatial index
-    sindex_fn = cutout.path.with_suffix(".sindex.pickle")
-    cutout._grid_cells.to_file(sindex_fn)

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -134,41 +134,6 @@ def compute_indicatormatrix(orig, dest, orig_proj='latlong', dest_proj='latlong'
 
     return indicator
 
-class GridCells:
-    def __init__(self, grid_cells, sindex, projection):
-        self.grid_cells = grid_cells
-        self.sindex = sindex
-        self.projection = projection
-
-    @classmethod
-    def from_cutout(cls, cutout):
-        coords = cutout.grid_coordinates()
-        span = (coords[cutout.shape[1]+1] - coords[0]) / 2
-        grid_cells = [box(*c) for c in np.hstack((coords - span, coords + span))]
-        sindex = Index((j, o.bounds, None) for j, o in enumerate(grid_cells))
-
-        return cls(grid_cells, sindex, cutout.projection)
-
-    @staticmethod
-    def from_file(filename):
-        pass
-
-    def to_file(self, filename):
-        # Turns out the spatial index gets distorted by pickling, so we turn this
-        # into a no-op, until we figure out a work-around
-        pass
-
-    def indicatormatrix(self, shapes, shapes_projection='latlong'):
-        shapes = reproject_shapes(shapes, shapes_projection, self.projection)
-        indicator = sp.sparse.lil_matrix((len(shapes), len(self.grid_cells)), dtype=np.float)
-
-        for i, s in enumerate(shapes):
-            for j in self.sindex.intersection(s.bounds):
-                o = self.grid_cells[j]
-                area = s.intersection(o).area
-                indicator[i,j] = area/o.area
-
-        return indicator
 
 def maybe_swap_spatial_dims(ds, namex='x', namey='y'):
     swaps = {}

--- a/atlite/utils.py
+++ b/atlite/utils.py
@@ -100,3 +100,26 @@ class arrowdict(dict):
                     dict_keys.append(m.string)
         return dict_keys
 
+
+class CachedAttribute(object):
+    '''
+    Computes attribute value and caches it in the instance.
+    From the Python Cookbook (Denis Otkidach)
+    This decorator allows you to create a property which can be
+    computed once and accessed many times. Sort of like memoization.
+    '''
+    def __init__(self, method, name=None, doc=None):
+        # record the unbound-method and the name
+        self.method = method
+        self.name = name or method.__name__
+        self.__doc__ = doc or method.__doc__
+    def __get__(self, inst, cls):
+        if inst is None:
+            # instance attribute accessed on class, return self
+            # You get here if you write `Foo.bar`
+            return self
+        # compute, cache and return the instance's attribute value
+        result = self.method(inst)
+        # setattr redefines the instance's attribute so this doesn't get called again
+        setattr(inst, self.name, result)
+        return result


### PR DESCRIPTION
Shapely provides its own 'rtree' for filtering out shapes which cannot intersect with each other. 

This change includes the [shapely.ops.strtree functionality](https://shapely.readthedocs.io/en/latest/manual.html#strtree.STRtree). Therefore the backup code in `compute_indicatormatrix` is obsolete. 

The speed gain is about 90%
