### PR TITLE
sarah: fix file parsing with pandas Period

### DIFF
--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -64,13 +64,7 @@ def _get_filenames(sarah_dir, period):
     if isinstance(period, (str, slice)):
         selector = period
     elif isinstance(period, pd.Period):
-        if isinstance(period.freq, pd.tseries.frequencies.Day):
-            format_string = "%Y-%m-%d"
-        elif isinstance(period.freq, pd.tseries.offsets.MonthOffset):
-            format_string = "%Y-%m"
-        else:
-            format_string = "%Y-%m"
-        selector = period.strftime(format_string)
+        selector = str(period)
     elif isinstance(period, pd.Timestamp):
         # Files are daily, anyway
         selector = period.strftime("%Y-%m-%d")


### PR DESCRIPTION
When creating a cutout for a whole year, with `module='sarah'`, the sarah data is only included for the last month. The bug is caused by a wrong assignment when parsing the raw sarah files. This PR fixes this bug, by searching for all files which begin with 
```python
str(period)
```
in case `period` is a `pandas.Period` 