### PR TITLE
setup: Use git tag versioning

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include atlite/resources/*/*.yaml
-include README.rst LICENSE.txt
-#include requirements.yml

--- a/atlite/__init__.py
+++ b/atlite/__init__.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 from .cutout import Cutout
 from .gis import compute_indicatormatrix, regrid
 
-from ._version import __version__
+from .version import version as __version__
 
 __author__ = "Gorm Andresen (Aarhus University), Jonas Hoersch (FIAS), Tom Brown (FIAS), Markus Schlott (FIAS), David Schlachtberger (FIAS)"
 __copyright__ = "Copyright 2016-2017 Gorm Andresen (Aarhus University), Jonas Hoersch (FIAS), Tom Brown (FIAS), Markus Schlott (FIAS), David Schlachtberger (FIAS), GNU GPL 3"

--- a/atlite/_version.py
+++ b/atlite/_version.py
@@ -1,2 +1,0 @@
-# Store the version a single place. We import it in setup.py and __init__.py.
-__version__ = '0.0.2'

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,22 @@
 from __future__ import absolute_import
 
 from setuptools import setup, find_packages
-from codecs import open
-import six
 
 with open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
-exec(open('atlite/_version.py').read())
-
 setup(
     name='atlite',
-    version=__version__,
     author='Jonas Hoersch (FIAS), Tom Brown (FIAS), Gorm Andresen (Aarhus University)',
     author_email='jonas.hoersch@posteo.de',
     description='Library for fetching and converting weather data to power systems data',
     long_description=long_description,
-    url='https://github.com/FRESNA/atlite',
+    url='https://github.com/PyPSA/atlite',
     license='GPLv3',
     packages=find_packages(exclude=['doc', 'test']),
     include_package_data=True,
+    use_scm_version={'write_to': 'atlite/version.py'},
+    setup_requires=['setuptools_scm'],
     install_requires=['numpy',
                       'scipy',
                       'pandas>=0.22',


### PR DESCRIPTION
Uses [setuptools_scm](https://github.com/pypa/setuptools_scm) to:
- compute a version number based on the latest git tag
- write it to `atlite/version.py`
- superseed MANIFEST.in (auto-generated by listing git repo)

No need to adapt `_version.py` anymore.

