### PR TITLE
era5: request only one dataset per feature

### DIFF
--- a/atlite/data.py
+++ b/atlite/data.py
@@ -95,12 +95,6 @@ def cutout_prepare(cutout, features=slice(None), tmpdir=None, overwrite=False):
         Cutout with prepared data. The variables are stored in `cutout.data`.
 
     """
-    if tmpdir is None:
-        tmpdir = mkdtemp()
-        keep_tmpdir = False
-    else:
-        keep_tmpdir = True
-
     modules = atleast_1d(cutout.module)
     features = atleast_1d(features)
     prepared = set(cutout.data.attrs['prepared_features'])
@@ -134,9 +128,6 @@ def cutout_prepare(cutout, features=slice(None), tmpdir=None, overwrite=False):
                 mode = 'w'
 
             ds.to_netcdf(cutout.path, mode=mode)
-
-    if not keep_tmpdir:
-        rmtree(tmpdir)
 
     cutout.data = xr.open_dataset(cutout.path, chunks=cutout.chunks)
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -12,13 +12,9 @@ https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation
 """
 
 import os
-import pandas as pd
 import numpy as np
 import xarray as xr
-import dask
-from dask import delayed
 from tempfile import mkstemp
-import weakref
 import cdsapi
 
 from ..gis import maybe_swap_spatial_dims
@@ -256,6 +252,8 @@ def get_data(cutout, feature, tmpdir, **creation_parameters):
     """
     sanitize = creation_parameters.get('sanitize', True)
 
+    # add chunk and tmpdir argument to the parameters, these two will be
+    # fetched out later in retrieve_data
     retrieval_params = {'product': 'reanalysis-era5-single-levels',
                         'area': _area(cutout.coords),
                         'tmpdir': tmpdir,

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -207,7 +207,6 @@ def retrieval_times(coords, static=False):
 
 def noisy_unlink(path):
     """Delete file at given path."""
-    logger.info(f"Deleting file {path}")
     try:
         os.unlink(path)
     except PermissionError:
@@ -280,11 +279,13 @@ def get_data(cutout, feature, tmpdir, **creation_parameters):
     func = globals().get(f"get_data_{feature}")
     sanitize_func = globals().get(f"sanitize_{feature}")
 
-    logger.info(f"Downloading data for feature '{feature}' to {tmpdir}.")
+    logger.info(f"Downloading data for feature '{feature}'.")
 
     ds = func(retrieval_params)
     if sanitize and sanitize_func is not None:
         ds = sanitize_func(ds)
     if is_static:
         ds = ds.squeeze().drop('time').assign_coords(time=cutout.data.time)
+    else:
+        ds = ds.sel(time=cutout.data.time)
     return ds


### PR DESCRIPTION
As detected by @euronion, the era5 download leads to weird (for me explainable) errors in some cases. This has to do with the delayed concatenation of datasets which are stored in temporary .nc files. This PR solves this issue by downloading only one temporary netcdf file per feature. 

Further advantage: 
* Use cdsapi progressbar to track the download, looks nice and gives a good estimation of remaining downloading time
* the code becomes clearer as we don't have to loop over several request for one variable