### PR TITLE
data: Re-enable parallelized queueing

### DIFF
--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -210,17 +210,17 @@ def retrieval_times(coords):
     time = pd.Series(coords['time'])
     time_span = time.iloc[-1] - time.iloc[0]
     if len(time) == 1:
-        return [{'year': d.year, 'month': d.month, 'day': d.day,
+        return [{'year': str(d.year), 'month': str(d.month), 'day': str(d.day),
                  'time': d.strftime("%H:00")} for d in time]
     if time_span.days <= 10:
-        return [{'year': d.year, 'month': d.month, 'day': d.day}
+        return [{'year': str(d.year), 'month': str(d.month), 'day': str(d.day)}
                 for d in time.dt.date.unique()]
     elif time_span.days < 90:
-        return [{'year': year, 'month': month}
+        return [{'year': str(year), 'month': str(month)}
                 for month in time.dt.month.unique()
                 for year in time.dt.year.unique()]
     else:
-        return [{'year': year} for year in time.dt.year.unique()]
+        return [{'year': str(year)} for year in time.dt.year.unique()]
 
 
 def noisy_unlink(path):

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -28,12 +28,6 @@ from ..gis import maybe_swap_spatial_dims
 import logging
 logger = logging.getLogger(__name__)
 
-import urllib3
-logger.warning('Disable urllib3 and cdsapi warnings.')
-# urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-# logging.getLogger("cdsapi").setLevel(logging.ERROR)
-
-
 # Model and Projection Settings
 projection = 'latlong'
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -214,7 +214,7 @@ def retrieval_times(coords):
 
     """
     time = pd.Series(coords['time'])
-    time_span = time[0] - time[len(time)-1]
+    time_span = time.iloc[-1] - time.iloc[0]
     if len(time) == 1:
         return [{'year': d.year, 'month': d.month, 'day': d.day,
                  'time': d.strftime("%H:00")} for d in time]

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -134,7 +134,7 @@ def hourly_mean(ds):
     return ds
 
 
-def get_data(cutout, feature, tmpdir, **creation_parameters):
+def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
     """
     Load stored SARAH data and reformat to matching the given cutout.
 


### PR DESCRIPTION
Since queueing time is dominant for downloading from ERA-5, I'd propose
to at least have some parallelized support for queueing.

This PR ...
- fixes two bugs with `era5.retrieval_times`
- re-enables warnings
- adds per-dataset dask.delayed concurrency
- introduces a lock to keep progress bars from breaking one another

Would be an alternative for #86 . But might not fix the original reason for it.