### PR TITLE
Fix divisions by zero

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -269,7 +269,8 @@ def convert_solar_thermal(ds, orientation, trigon_model, clearsky_model,
 
     # overall efficiency; can be negative, so need to remove negative values
     # below
-    eta = c0 - c1 * ((t_store - ds['temperature']) / irradiation)
+    eta = c0 - c1 * ((t_store - ds['temperature']) /
+                     irradiation.where(irradiation!=0)).fillna(0)
 
     output = irradiation * eta
 

--- a/atlite/pv/irradiation.py
+++ b/atlite/pv/irradiation.py
@@ -87,7 +87,7 @@ def TiltedDiffuseIrrad(
 
     with np.errstate(divide='ignore', invalid='ignore'):
         # brightening factor
-        f = sqrt(direct / influx).fillna(0.)
+        f = sqrt(direct / influx.where(influx!=0)).fillna(0.)
 
         # anisotropy factor
         A = direct / atmospheric_insolation
@@ -126,8 +126,7 @@ def _albedo(ds, influx):
     if 'albedo' in ds:
         albedo = ds['albedo']
     elif 'outflux' in ds:
-        with np.errstate(divide='ignore', invalid='ignore'):
-            albedo = (ds['outflux'] / influx).clip(max=1.)
+        albedo = (ds['outflux'] / influx.where(influx!=0)).fillna(0).clip(max=1)
     else:
         raise AssertionError(
             "Need either albedo or outflux as a variable in the dataset. "

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -30,15 +30,13 @@ def _power_huld(irradiance, t_amb, pc):
     # normalized irradiance
     G_ = irradiance / pc['r_irradiance']
 
-    # Suppress divide-by-zero and invalid-value warnings in log for G_ = 0
-    with np.errstate(invalid='ignore', divide='ignore'):
-        # NB: np.log without base implies base e or ln
-        eff = (1 + pc['k_1'] * np.log(G_) + pc['k_2'] * (np.log(G_)) ** 2 +
-               T_ * (pc['k_3'] + pc['k_4'] * np.log(G_) +
-                     pc['k_5'] * (np.log(G_)) ** 2) +
-               pc['k_6'] * (T_ ** 2))
+    log_G_ = np.log(G_.where(G_!=0))
+    # NB: np.log without base implies base e or ln
+    eff = (1 + pc['k_1'] * log_G_ + pc['k_2'] * (log_G_) ** 2 +
+           T_ * (pc['k_3'] + pc['k_4'] * log_G_ + pc['k_5'] * log_G_ ** 2) +
+           pc['k_6'] * (T_ ** 2))
 
-        eff = eff.fillna(0.).clip(min=0)
+    eff = eff.fillna(0.).clip(min=0)
 
     return G_ * eff * pc.get('inverter_efficiency', 1.)
 
@@ -56,16 +54,16 @@ def _power_bofinger(irradiance, t_amb, pc):
 
     fraction = (pc['NOCT'] - pc['Tamb']) / pc['Intc']
 
-    with np.errstate(divide='ignore', invalid='ignore'):
-        eta_ref = (
-            pc['A'] +
-            pc['B'] *
-            irradiance +
-            pc['C'] *
-            np.log(irradiance))
-        eta = (eta_ref *
-               (1. + pc['D'] * (fraction * irradiance + (t_amb - pc['Tstd']))) /
-               (1. + pc['D'] * fraction / pc['ta'] * eta_ref * irradiance))
+    eta_ref = (
+        pc['A'] +
+        pc['B'] *
+        irradiance +
+        pc['C'] *
+        np.log(irradiance.where(irradiance!=0)))
+    eta = (eta_ref *
+           (1. + pc['D'] * (fraction * irradiance + (t_amb - pc['Tstd']))) /
+           (1. + pc['D'] * fraction / pc['ta'] * eta_ref * irradiance)
+           ).fillna(0)
 
     capacity = (pc['A'] + pc['B'] * 1000. + pc['C'] * np.log(1000.)) * 1e3
     power = irradiance * eta * (pc.get('inverter_efficiency', 1.) / capacity)

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -30,7 +30,7 @@ def _power_huld(irradiance, t_amb, pc):
     # normalized irradiance
     G_ = irradiance / pc['r_irradiance']
 
-    log_G_ = np.log(G_.where(G_!=0))
+    log_G_ = np.log(G_.where(G_>0))
     # NB: np.log without base implies base e or ln
     eff = (1 + pc['k_1'] * log_G_ + pc['k_2'] * (log_G_) ** 2 +
            T_ * (pc['k_3'] + pc['k_4'] * log_G_ + pc['k_5'] * log_G_ ** 2) +


### PR DESCRIPTION
This PR fixes RuntimeWarnings caused by dividing with zero. Before these were suppressed by np.errstate which however is ignored by dask.
 
solves #55