### PR TITLE
Add PROJ>=7 valid 'aea' projection string

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -548,6 +548,11 @@ def hydro(cutout, plants, hydrobasins, flowspeed=1, weight_with_height=False, sh
                            **kwargs)
     # The hydrological parameters are in units of "m of water per day" and so
     # they should be multiplied by 1000 and the basin area to convert to m3 d-1 = m3 h-1 / 24
-    runoff *= (1000. / 24.) * xr.DataArray(basins.shapes.to_crs(dict(proj="aea")).area)
+    bounds = basins.shapes.total_bounds
+    # Least distortion in Albers Equals Area comes from centering the projection over basin shapes
+    proj = '+proj=aea +lon_0={} +lat_1={} +lat_2={}'.format(
+        (bounds[0] + bounds[2]) / 2, bounds[1], bounds[3]
+    )
+    runoff *= (1000. / 24.) * xr.DataArray(basins.shapes.to_crs(proj).area)
 
     return hydrom.shift_and_aggregate_runoff_for_plants(basins, runoff, flowspeed, show_progress)


### PR DESCRIPTION
PROJ >=v7.0 is default on conda-forge now, which impacts the version of pyproj which atlite installs (>=v2.5). In fact, PROJ <=v7.0 is no longer on the `main` channel on conda-forge. This means that more information is required to reproject to Albers Equal Area. I've designed it to choose the AEA parameters based on the bounds of the input shapes, but this projection (and any equal area one) is liable to distortion if the bounds become too large (~few thousand km, I believe).

This PR fixes the following error raised when using the `conversion.hydro` method with a fresh install of atlite 0.0.3:

```python
  File "/path/to/atlite/convert.py", line 551, in hydro
    runoff *= (1000. / 24.) * xr.DataArray(basins.shapes.to_crs(dict(proj="aea")).area)
  File "/path/to/geopandas/geoseries.py", line 531, in to_crs
    crs = CRS.from_user_input(crs)
  File "/path/to/pyproj/crs/crs.py", line 437, in from_user_input
    return CRS(value)
  File "/path/to/pyproj/crs/crs.py", line 293, in __init__
    super().__init__(projstring)
  File "pyproj/_crs.pyx", line 2313, in pyproj._crs._CRS.__init__
pyproj.exceptions.CRSError: Invalid projection: +proj=aea +type=crs: (Internal Proj Error: proj_create: Error -21: conic lat_1 = -lat_2)
```
