### PR TITLE
Modified cutout creation

### DIFF
--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -156,8 +156,8 @@ class Cutout:
             data = xr.open_dataset(str(path), chunks=chunks)
             data.attrs.update(storable_chunks)
             if cutoutparams:
-                warn(f'Arguments {cutoutparams} are ignored, since cutout '
-                     'is already built.')
+                warn(f'Arguments {", ".join(cutoutparams)} are ignored, since '
+                     'cutout is already built.')
         elif 'data' in cutoutparams:
             data = cutoutparams.pop('data')
         else:

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -155,13 +155,9 @@ class Cutout:
         if path.is_file():
             data = xr.open_dataset(str(path), chunks=chunks)
             data.attrs.update(storable_chunks)
-            if 'module' in cutoutparams:
-                module = cutoutparams.pop('module')
-                if module != data.attrs.get('module'):
-                    logger.warning(
-                        f"Overwriting dataset module "
-                        f"{data.attrs.get('module')} with module {module}.")
-                data.attrs['module'] = module
+            if cutoutparams:
+                warn(f'Arguments {cutoutparams} are ignored, since cutout '
+                     'is already built.')
         elif 'data' in cutoutparams:
             data = cutoutparams.pop('data')
         else:
@@ -255,9 +251,8 @@ class Cutout:
 
     @property
     def prepared(self):
-        warn("The `prepared` attribute is deprecated in favour of the "
-             "fine-grained `prepared_features` list", DeprecationWarning)
-        return self.prepared_features == self.available_features
+        return (self.prepared_features.sort_index()
+                .equals(self.available_features.sort_index()))
 
     @property
     def prepared_features(self):

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -123,6 +123,10 @@ def cutout_prepare(cutout, features=None, tmpdir=None, overwrite=False):
         Cutout with prepared data. The variables are stored in `cutout.data`.
 
     """
+    if cutout.prepared and not overwrite:
+        logger.info('Cutout already prepared.')
+        return cutout
+
     logger.info(f'Storing temporary files in {tmpdir}')
 
     modules = atleast_1d(cutout.module)

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -39,6 +39,11 @@ def update_feature_test(cutout, red):
     assert_equal(red.data.influx_direct, cutout.data.influx_direct)
 
 
+def wrong_recreation(cutout):
+    with pytest.warns(UserWarning):
+        Cutout(path=cutout.path, module='somethingelse')
+
+
 def pv_test(cutout):
     '''
     Test the atlite.Cutout.pv function with different settings. Compare
@@ -203,6 +208,10 @@ class TestERA5:
     @staticmethod
     def test_update_feature_era5(cutout_era5, cutout_era5_reduced):
         return update_feature_test(cutout_era5, cutout_era5_reduced)
+
+    @staticmethod
+    def test_wrong_loading(cutout_era5):
+        wrong_recreation(cutout_era5)
 
     @staticmethod
     def test_pv_era5(cutout_era5):


### PR DESCRIPTION
As soon as a cutout is already created, the underlying cutout parameters should be immutable. With this, atlite warns about ignoring cutoutparams, if they are passed anyway.    

Secondly, fix Cutout.prepared and undo its deprecation