### PR TITLE
data.py set "feature" attribute for every variable

### DIFF
--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -256,8 +256,10 @@ class Cutout:
 
     @property
     def prepared_features(self):
-        features = atleast_1d(self.data.attrs.get("prepared_features", []))
-        return self.available_features.loc[:, features].drop_duplicates()
+        index = [(self.data[v].attrs['module'], self.data[v].attrs['feature'])
+                 for v in self.data]
+        index = pd.MultiIndex.from_tuples(index, names=['module', 'feature'])
+        return pd.Series(list(self.data), index)
 
     def grid_coordinates(self):
         warn("The function `grid_coordinates` has been deprecated in favour of "

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -41,6 +41,8 @@ def get_features(cutout, module, features, tmpdir=None):
     ds = xr.merge(datasets, compat='equals')
     for v in ds:
         ds[v].attrs['module'] = module
+        fd = datamodules[module].features.items()
+        ds[v].attrs['feature'] = [k for k, l in fd if v in l].pop()
     return ds
 
 


### PR DESCRIPTION
The previous behavior that the prepared_feature series was build from a lookup list only was not secure for cutouts with mixed modules. This makes the function robust