### PR TITLE
Cutout merge

### DIFF
--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -289,7 +289,7 @@ class Cutout:
 
     def sel(self, path=None, bounds=None, buffer=0, **kwargs):
         '''
-        Select parts of the cutout and save output to a file.
+        Select parts of the cutout.
 
         Parameters
         ----------
@@ -324,8 +324,7 @@ class Cutout:
 
     def merge(self, other, path=None, **kwargs):
         '''
-        Merge two cutouts into a single cutout and save output to a file.
-
+        Merge two cutouts into a single cutout.
 
         Parameters
         ----------
@@ -360,6 +359,15 @@ class Cutout:
 
 
     def to_file(self, fn=None):
+        '''
+        Save cutout to a netcdf file.
+
+        Parameters
+        ----------
+        fn : str | path-like
+            File name where to store the cutout, defaults to `cutout.path`.
+
+        '''
         if fn is None:
             fn = self.path
         self.data.to_netcdf(fn)

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -287,6 +287,28 @@ class Cutout:
 
 
     def sel(self, path=None, bounds=None, buffer=0, **kwargs):
+        '''
+        Select parts of the cutout and save output to a file.
+
+        Parameters
+        ----------
+        path : str | path-like
+            Non-existent filename where to store the sub-cutout.
+            Defaults to a temporary file.
+        bounds : GeoSeries.bounds | DataFrame, optional
+            The outer bounds of the cutout or as a DataFrame
+            containing (min.long, min.lat, max.long, max.lat).
+        buffer : float, optional
+            Buffer around the bounds. The default is 0.
+        **kwargs :
+            Passed to `xr.Dataset.sel` for data selection.
+
+        Returns
+        -------
+        selected : Cutout
+            Selected cutout.
+
+        '''
         if path is None:
             path = mktemp(prefix=f"{self.path.stem}-", suffix=self.path.suffix,
                           dir=self.path.parent)
@@ -303,8 +325,7 @@ class Cutout:
 
     def merge(self, other, path=None, **kwargs):
         '''
-        Merge two cutouts into a single cutout.
-
+        Merge two cutouts into a single cutout and save output to a file.
 
 
         Parameters
@@ -312,8 +333,8 @@ class Cutout:
         other : atlite.Cutout
             Other cutout to merge.
         path : str | path-like
-            File where to store the merged cutout. Defaults to a temporary file.
-            Has to be a non-existent filename.
+            Non-existent filename where to store the merged cutout.
+            Defaults to a temporary file.
         **kwargs
             Keyword arguments passed to `xarray.merge()`.
 

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -312,7 +312,6 @@ class Cutout:
         if path is None:
             path = mktemp(prefix=f"{self.path.stem}-", suffix=self.path.suffix,
                           dir=self.path.parent)
-        assert not Path(path).with_suffix(".nc").exists()
 
         if bounds is not None:
             if buffer > 0:

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -96,7 +96,8 @@ class Cutout:
             Chunks when opening netcdf files. For cutout preparation recommand
             to chunk only along the time dimension. Defaults to {'time': 20}
         data : xr.Dataset
-            User provided cutout data.
+            User provided cutout data. The data will directly be stored at
+            `path`.
 
         Other Parameters
         ----------------
@@ -160,6 +161,7 @@ class Cutout:
                      'cutout is already built.')
         elif 'data' in cutoutparams:
             data = cutoutparams.pop('data')
+            data.to_netcdf(path)
         else:
             logger.info(f"Building new cutout {path}")
 
@@ -288,6 +290,7 @@ class Cutout:
         if path is None:
             path = mktemp(prefix=f"{self.path.stem}-", suffix=self.path.suffix,
                           dir=self.path.parent)
+        assert not Path(path).with_suffix(".nc").exists()
 
         if bounds is not None:
             if buffer > 0:
@@ -303,13 +306,14 @@ class Cutout:
         Merge two cutouts into a single cutout.
 
 
+
         Parameters
         ----------
         other : atlite.Cutout
             Other cutout to merge.
         path : str | path-like
             File where to store the merged cutout. Defaults to a temporary file.
-            For inplace modification set to `cutout.path`.
+            Has to be a non-existent filename.
         **kwargs
             Keyword arguments passed to `xarray.merge()`.
 
@@ -324,6 +328,7 @@ class Cutout:
         if path is None:
             path = mktemp(prefix=f"{self.path.stem}-", suffix=self.path.suffix,
                           dir=self.path.parent)
+        assert not Path(path).with_suffix(".nc").exists()
 
         attrs = {**self.data.attrs, **other.data.attrs}
         attrs['module'] = list(set(append(*atleast_1d(self.module, other.module))))

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -96,8 +96,8 @@ class Cutout:
             Chunks when opening netcdf files. For cutout preparation recommand
             to chunk only along the time dimension. Defaults to {'time': 20}
         data : xr.Dataset
-            User provided cutout data. The data will directly be stored at
-            `path`.
+            User provided cutout data. Save the cutout using `Cutout.to_file()`
+            afterwards.
 
         Other Parameters
         ----------------
@@ -161,7 +161,6 @@ class Cutout:
                      'cutout is already built.')
         elif 'data' in cutoutparams:
             data = cutoutparams.pop('data')
-            data.to_netcdf(path)
         else:
             logger.info(f"Building new cutout {path}")
 
@@ -293,8 +292,7 @@ class Cutout:
         Parameters
         ----------
         path : str | path-like
-            Non-existent filename where to store the sub-cutout.
-            Defaults to a temporary file.
+            File where to store the sub-cutout. Defaults to a temporary file.
         bounds : GeoSeries.bounds | DataFrame, optional
             The outer bounds of the cutout or as a DataFrame
             containing (min.long, min.lat, max.long, max.lat).
@@ -333,8 +331,7 @@ class Cutout:
         other : atlite.Cutout
             Other cutout to merge.
         path : str | path-like
-            Non-existent filename where to store the merged cutout.
-            Defaults to a temporary file.
+            File where to store the merged cutout. Defaults to a temporary file.
         **kwargs
             Keyword arguments passed to `xarray.merge()`.
 
@@ -349,7 +346,6 @@ class Cutout:
         if path is None:
             path = mktemp(prefix=f"{self.path.stem}-", suffix=self.path.suffix,
                           dir=self.path.parent)
-        assert not Path(path).with_suffix(".nc").exists()
 
         attrs = {**self.data.attrs, **other.data.attrs}
         attrs['module'] = list(set(append(*atleast_1d(self.module, other.module))))
@@ -361,6 +357,11 @@ class Cutout:
 
         return Cutout(path, data=data)
 
+
+    def to_file(self, fn=None):
+        if fn is None:
+            fn = self.path
+        self.data.to_netcdf(fn)
 
 
     def __repr__(self):

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -39,6 +39,11 @@ def update_feature_test(cutout, red):
     assert_equal(red.data.influx_direct, cutout.data.influx_direct)
 
 
+def merge_test(cutout, other, target_modules):
+    merge = cutout.merge(other, compat='override')
+    assert set(merge.module) == set(target_modules)
+
+
 def pv_test(cutout):
     '''
     Test the atlite.Cutout.pv function with different settings. Compare
@@ -226,8 +231,13 @@ class TestSarah:
         return prepared_features_test(cutout_sarah)
 
     @staticmethod
+    def test_merge(cutout_sarah, cutout_era5):
+        return merge_test(cutout_sarah, cutout_era5, ['sarah', 'era5'])
+
+    @staticmethod
     def test_pv_sarah(cutout_sarah):
         return pv_test(cutout_sarah)
+
 
     @staticmethod
     def test_wind_sarah(cutout_sarah):


### PR DESCRIPTION
Enable to merge two different cutouts. Add function `to_file()` for explicitly writing out cutout. 