### PR TITLE
Fix coordinates corruption ERA5

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,9 +8,11 @@ Release Notes
 #############
 
 
-.. Version 0.2.1 
-.. =========
-.. Untoggle this and add first release note for the next version
+Version 0.2.1 
+=========
+* Fix resolution for dx and dy unequal to 0.25: Due to floating point precision errors, loading data with ERA5 corrupted the cutout coordinates. This was fixed by converting the dtype of era5 coordinates to float64 and rounding. Corresponding tests were added.
+* Round cutout.dx and cutout.dy in order to prevent precision errors.    
+
 
 
 Version 0.2

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -239,12 +239,12 @@ class Cutout:
     @property
     def dx(self):
         x = self.coords['x']
-        return (x[-1] - x[0]).item() / (x.size - 1)
+        return round((x[-1] - x[0]).item() / (x.size - 1), 8)
 
     @property
     def dy(self):
         y = self.coords['y']
-        return (y[-1] - y[0]).item() / (y.size - 1)
+        return round((y[-1] - y[0]).item() / (y.size - 1), 8)
 
     @property
     def dt(self):

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -74,12 +74,15 @@ def _add_height(ds):
 
 
 def _rename_and_clean_coords(ds, add_lon_lat=True):
-    """Rename 'longitude' and 'latitude' columns to 'x' and 'y'.
+    """Rename 'longitude' and 'latitude' columns to 'x' and 'y' and fix roundings.
 
     Optionally (add_lon_lat, default:True) preserves latitude and longitude
     columns as 'lat' and 'lon'.
     """
     ds = ds.rename({'longitude': 'x', 'latitude': 'y'})
+    # round coords since cds coords are float32 which would lead to mismatches
+    ds = ds.assign_coords(x=np.round(ds.x.astype(float), 5),
+                          y=np.round(ds.y.astype(float), 5))
     ds = maybe_swap_spatial_dims(ds)
     if add_lon_lat:
         ds = ds.assign_coords(lon=ds.coords['x'], lat=ds.coords['y'])

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -55,8 +55,8 @@ def get_coords(x, y, time, dx=0.25, dy=0.25, dt='h', **kwargs):
     x = slice(*sorted([x.start, x.stop]))
     y = slice(*sorted([y.start, y.stop]))
 
-    ds = xr.Dataset({'x': np.arange(-180, 180, dx),
-                     'y': np.arange(-90, 90, dy),
+    ds = xr.Dataset({'x': np.round(np.arange(-180, 180, dx), 9),
+                     'y': np.round(np.arange(-90, 90, dy), 9),
                      'time': pd.date_range(start="1979", end="now", freq=dt)})
     ds = ds.assign_coords(lon=ds.coords['x'], lat=ds.coords['y'])
     ds = ds.sel(x=x, y=y, time=time)

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -219,24 +219,42 @@ class TestERA5:
 
     @staticmethod
     def test_all_non_na_era5(cutout_era5):
-        """
-        Every cells should have data
-        """
+        """Every cells should have data."""
         assert np.isfinite(cutout_era5.data).all()
 
     @staticmethod
     def test_all_non_na_era5_coarse(cutout_era5_coarse):
-        """
-        Every cells should have data
-        """
+        """Every cells should have data."""
         assert np.isfinite(cutout_era5_coarse.data).all()
 
     @staticmethod
     def test_all_non_na_era5_weird(cutout_era5_weird):
-        """
-        Every cells should have data
-        """
+        """Every cells should have data."""
         assert np.isfinite(cutout_era5_weird.data).all()
+
+
+    @staticmethod
+    def test_dx_dy_preservation_era5(cutout_era5):
+        """The coordinates should be the same after preparation."""
+        assert np.allclose(np.diff(cutout_era5.data.x), 0.25)
+        assert np.allclose(np.diff(cutout_era5.data.y), 0.25)
+
+    @staticmethod
+    def test_dx_dy_preservation_era5_coarse(cutout_era5_coarse):
+        """The coordinates should be the same after preparation."""
+        assert np.allclose(np.diff(cutout_era5_coarse.data.x),
+                           cutout_era5_coarse.data.attrs['dx'])
+        assert np.allclose(np.diff(cutout_era5_coarse.data.y),
+                           cutout_era5_coarse.data.attrs['dy'])
+
+    @staticmethod
+    def test_dx_dy_preservation_era5_weird(cutout_era5_weird):
+        """The coordinates should be the same after preparation."""
+        assert np.allclose(np.diff(cutout_era5_weird.data.x),
+                           cutout_era5_weird.data.attrs['dx'])
+        assert np.allclose(np.diff(cutout_era5_weird.data.y),
+                           cutout_era5_weird.data.attrs['dy'])
+
 
     @staticmethod
     def test_compare_with_get_data_era5(cutout_era5, tmp_path):

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -7,6 +7,7 @@ Created on Mon May 11 11:15:41 2020
 """
 
 import os
+import sys
 import pytest
 import urllib3
 import geopandas as gpd
@@ -269,6 +270,8 @@ class TestERA5:
         return prepared_features_test(cutout_era5)
 
     @staticmethod
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason='NetCDF update not working on windows')
     def test_update_feature_era5(cutout_era5, cutout_era5_reduced):
         return update_feature_test(cutout_era5, cutout_era5_reduced)
 

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -170,6 +170,25 @@ def cutout_era5(tmp_path_factory):
     cutout.prepare()
     return cutout
 
+
+@pytest.fixture(scope='session')
+def cutout_era5_coarse(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("era5_coarse")
+    cutout = Cutout(path=tmp_path / "era5", module="era5", bounds=BOUNDS,
+                    time=TIME, dx=0.5, dy=0.7)
+    cutout.prepare()
+    return cutout
+
+
+@pytest.fixture(scope='session')
+def cutout_era5_weird(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("era5_weird")
+    cutout = Cutout(path=tmp_path / "era5", module="era5", bounds=BOUNDS,
+                    time=TIME, dx=0.132, dy=0.32)
+    cutout.prepare()
+    return cutout
+
+
 @pytest.fixture(scope='session')
 def cutout_era5_reduced(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("era5_red")
@@ -197,6 +216,27 @@ class TestERA5:
         """
         for v in cutout_era5.data:
             assert cutout_era5.data.attrs['module'] == 'era5'
+
+    @staticmethod
+    def test_all_non_na_era5(cutout_era5):
+        """
+        Every cells should have data
+        """
+        assert np.isfinite(cutout_era5.data).all()
+
+    @staticmethod
+    def test_all_non_na_era5_coarse(cutout_era5_coarse):
+        """
+        Every cells should have data
+        """
+        assert np.isfinite(cutout_era5_coarse.data).all()
+
+    @staticmethod
+    def test_all_non_na_era5_weird(cutout_era5_weird):
+        """
+        Every cells should have data
+        """
+        assert np.isfinite(cutout_era5_weird.data).all()
 
     @staticmethod
     def test_compare_with_get_data_era5(cutout_era5, tmp_path):


### PR DESCRIPTION
ERA5 coordinates have dtype float32. When merging into the cutout, this causes a corruption of the cutout coordinates. This only applies for dx and dy unequal to 0.25.  