### PR TITLE
Allow passing dask keyword arguments in conversion functions

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,7 +12,7 @@ Version 0.2.1
 =========
 * Fix resolution for dx and dy unequal to 0.25: Due to floating point precision errors, loading data with ERA5 corrupted the cutout coordinates. This was fixed by converting the dtype of era5 coordinates to float64 and rounding. Corresponding tests were added.
 * Round cutout.dx and cutout.dy in order to prevent precision errors.    
-
+* Allow passing keyword arguments to `dask.compute` in `convert_and_aggregate` functions. 
 
 
 Version 0.2

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -40,7 +40,7 @@ def convert_and_aggregate(cutout, convert_func, matrix=None,
                           index=None, layout=None, shapes=None,
                           shapes_crs=4326, per_unit=False,
                           return_capacity=False, capacity_factor=False,
-                          show_progress=True, **convert_kwds):
+                          show_progress=True, dask_kwargs={}, **convert_kwds):
     """
     Convert and aggregate a weather-based renewable generation time-series.
 
@@ -76,6 +76,8 @@ def convert_and_aggregate(cutout, convert_func, matrix=None,
         grid cell is computed.
     show_progress : boolean, default True
         Whether to show a progress bar.
+    dask_kwargs : dict, default {}
+        Dict with keywork arguments passed to `dask.compute`.
 
     Other Parameters
     -----------------
@@ -144,18 +146,18 @@ def convert_and_aggregate(cutout, convert_func, matrix=None,
 
 
     if return_capacity:
-        return maybe_progressbar(results, show_progress), capacity
+        return maybe_progressbar(results, show_progress, **dask_kwargs), capacity
     else:
-        return maybe_progressbar(results, show_progress)
+        return maybe_progressbar(results, show_progress, **dask_kwargs)
 
 
-def maybe_progressbar(ds, show_progress):
+def maybe_progressbar(ds, show_progress, **kwargs):
     """Load a xr.dataset with dask arrays either with or without progressbar."""
     if show_progress:
         with ProgressBar(minimum=2):
-            ds.load()
+            ds.load(**kwargs)
     else:
-        ds.load()
+        ds.load(**kwargs)
     return ds
 
 

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -77,7 +77,7 @@ def convert_and_aggregate(cutout, convert_func, matrix=None,
     show_progress : boolean, default True
         Whether to show a progress bar.
     dask_kwargs : dict, default {}
-        Dict with keywork arguments passed to `dask.compute`.
+        Dict with keyword arguments passed to `dask.compute`.
 
     Other Parameters
     -----------------


### PR DESCRIPTION
## Change proposed in this Pull Request

Add a new argument to `convert_and_aggregate` which is passed to dask.compute. This allows to properly set i.e. the number of workers (threads).

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added a note to release notes `doc/release_notes.rst`.
