### PR TITLE
Fix data `atlite.gis.regrid`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,6 +10,7 @@ Release Notes
 
 Version 0.2.1 (upcoming)
 =========================
+* The `regrid` function in `atlite.gis` was fixed. The previous implementation set an affine transform starting at the center of a cell at the origin. The corrected transform starts at the real origin (origin of the origin cell). Further a padding of the extent ensures that all values are taken into account in the target projection.  
 * Exclusion Calculation is now possible with `atlite` (find an usage example at Examples -> Calculate Landuse Availability), Therefore 
 
   - a new class  `atlite.gis.ExclusionContainer`  was added. It serves as a container of rasters and geometries which should be excluded from the landuse availability.  

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -526,7 +526,7 @@ def _as_transform(x, y):
     dx = float(rx - lx) / float(len(x) - 1)
     dy = float(uy - ly) / float(len(y) - 1)
 
-    return rio.transform.from_origin(lx, uy, dx, dy)
+    return rio.transform.from_origin(lx - dx/2, uy + dy/2, dx, dy)
 
 
 def regrid(ds, dimx, dimy, **kwargs):

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -124,7 +124,7 @@ def compute_indicatormatrix(orig, dest, orig_crs=4326, dest_crs=4326):
     Note that the polygons must be in the same crs.
 
     Parameters
-    ---------
+    ----------
     orig : Collection of shapely polygons
     dest : Collection of shapely polygons
 
@@ -307,16 +307,33 @@ def projected_mask(raster, geom, transform=None, shape=None, crs=None,
                               dst_transform=transform, dst_nodata=nodata)
 
 
-def pad_extent(values, src_transform, dst_transform, src_crs, dst_crs):
+def pad_extent(src, src_transform, dst_transform, src_crs, dst_crs, **kwargs):
     """
     Pad the extent such that the array is large enough to not be treated as
     nodata in all cells of the target raster.
+
+    If src.ndim > 2, the function expects the last two dimensions to be y,x.
+    Keyword arguments **kwargs are used in np.pad().
     """
+    if src.size == 0:
+        return src, src_transform
+
     left, top, right, bottom = *(src_transform*(0,0)), *(src_transform*(1,1))
     covered = transform_bounds(src_crs, dst_crs, left, bottom, right, top)
     covered_res = min(covered[2] - covered[0], covered[3] - covered[1])
     pad = int(dst_transform[0] // covered_res * 1.1)
-    return rio.pad(values, src_transform, pad, 'constant', constant_values=0)
+
+    kwargs.setdefault('mode', 'constant')
+
+    if src.ndim == 2:
+        return rio.pad(src, src_transform, pad, **kwargs)
+
+    npad = ((0,0),) * (src.ndim - 2) + ((pad, pad), (pad, pad))
+    padded = np.pad(src, npad, **kwargs)
+    transform = list(src_transform)
+    transform[2] -= pad * transform[0]
+    transform[5] -= pad * transform[4]
+    return padded, rio.Affine(*transform[:6])
 
 
 def shape_availability(geometry, excluder):
@@ -556,21 +573,22 @@ def regrid(ds, dimx, dimy, **kwargs):
 
     ds = maybe_swap_spatial_dims(ds, namex, namey)
 
-    src_transform = _as_transform(ds.indexes[namex],
-                                  ds.indexes[namey])
+    src_transform = _as_transform(ds.indexes[namex], ds.indexes[namey])
     dst_transform = _as_transform(dimx, dimy)
     dst_shape = len(dimy), len(dimx)
 
     kwargs.update(dst_shape=dst_shape,
-                  src_transform=src_transform,
                   dst_transform=dst_transform)
     kwargs.setdefault("src_crs", CRS.from_epsg(4326))
     kwargs.setdefault("dst_crs", CRS.from_epsg(4326))
 
     def _reproject(src, dst_shape, **kwargs):
-        dst = np.empty(src.shape[:-2] + dst_shape, dtype=src.dtype)
-        rio.warp.reproject(np.asarray(src), dst, **kwargs)
-        return dst
+        shape = src.shape[:-2] + dst_shape
+        src, trans = pad_extent(src, src_transform, dst_transform,
+                                kwargs['src_crs'], kwargs['dst_crs'], mode='edge')
+        return rio.warp.reproject(np.asarray(src), empty(shape, dtype=src.dtype),
+                                  src_transform=trans, **kwargs)[0]
+
 
     data_vars = ds.data_vars.values() if isinstance(ds, xr.Dataset) else (ds,)
     dtypes = {da.dtype for da in data_vars}


### PR DESCRIPTION
## Change proposed in this Pull Request

Fix `regrid` function in `atlite.gis`. The previous implementation set an affine transform starting at the center of a cell at the origin. The corrected transform starts at the real origin (origin of the origin cell). Further a padding of the extent ensures that all values are taken into account in the target projection. 

New tests for the `pad_extent` function were added.

## How Has This Been Tested?

```python
cutout = atlite.Cutout(path="sample",
        x=slice(20, 32), y=slice(33, 45),
        module="sarah",
        time=slice("2013-01-01", "2013-01-03"),
        sarah_dir='sarah_dir',
        sarah_interpolate=False,
        )
cutout.prepare()
```
in master produces:

![atlite-master-regrid](https://user-images.githubusercontent.com/19226431/109011636-67575e00-76b1-11eb-900b-0d94566d2ccd.png)

Watch out for the dark edges. 

The corrected version produces (using the same code)
![atlite-corrected-regrid](https://user-images.githubusercontent.com/19226431/109011730-848c2c80-76b1-11eb-88e0-24cb5fe09be5.png)


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
