### PR TITLE
cutout: adjust extent, add bounds propoerty

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,10 @@ Version 0.2.1 (upcoming)
 * Fix resolution for dx and dy unequal to 0.25: Due to floating point precision errors, loading data with ERA5 corrupted the cutout coordinates. This was fixed by converting the dtype of era5 coordinates to float64 and rounding. Corresponding tests were added.
 * Round cutout.dx and cutout.dy in order to prevent precision errors.    
 * Allow passing keyword arguments to `dask.compute` in `convert_and_aggregate` functions. 
+* The Cutout class has a new property `bounds` (same as extent but in different order).
+
+**Breaking Change**
+* `Cutout.extent` was adjusted to cover the whole cutout area. The extent is now a numpy array. Before, it indicated the coordinates of the centers of the corner cells. 
 
 Version 0.2
 ===============

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -234,8 +234,15 @@ class Cutout:
 
     @property
     def extent(self):
-        return (list(self.coords["x"].values[[0, -1]]) +
-                list(self.coords["y"].values[[0, -1]]))
+        """Total extent of the area covered by the cutout (x, X, y, Y)."""
+        xs, ys = self.coords['x'].values, self.coords['y'].values
+        dx , dy = self.dx, self.dy
+        return np.array([xs[0]-dx/2, xs[-1]+dx/2, ys[0]-dy/2, ys[-1]+dy/2])
+
+    @property
+    def bounds(self):
+        """Total bounds of the area covered by the cutout (x, y, X, Y)."""
+        return self.extent[[0,2,1,3]]
 
     @property
     def transform(self):

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -95,9 +95,13 @@ def test_grid_coords(ref):
     np.testing.assert_equal(gcoords, spatial)
 
 
-# Extent is different from bounds
 def test_extent(ref):
-    np.testing.assert_array_equal(ref.extent,[X0, X1, Y0, Y1])
+    pad = 0.25/2
+    np.testing.assert_array_equal(ref.extent,[X0-pad, X1+pad, Y0-pad, Y1+pad])
+
+# Note that bounds is the same as extent but in different order.
+def test_bounds(ref):
+    np.testing.assert_array_equal(ref.bounds, ref.grid.total_bounds)
 
 
 def test_pad_extent():


### PR DESCRIPTION
Adjust `Cutout.extent` to cover the whole cutout area. Before, it indicated the coordinates of the centers of the corner cells. 
Add a `Cutout.bounds` property. The extent is now a numpy array. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
