### PR TITLE
SARAH: fix fine grained resolution

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,7 @@ Version 0.2.2 (upcoming)
 ========================
 * Fixed compatibility with xarray v0.17.
 * Fixed sarah data for ``dx = dy = 0.05``. Due to the float32 dtype of the sarah coordinates, the cutout coordinates were corrupted when merging. This was fixed in the sarah module by converting the coordinates to float64. This also speeds up the cutout creation for more coarse grained cutouts.  
+* Fixed sarah data for a time frequency of 30 minutes. This was raising an assertion as is the (new) pandas frequency string for 30 minutes is '30T' not '30min'.
 
 Version 0.2.1
 ==============

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,9 +10,15 @@ Release Notes
 
 Version 0.2.2 (upcoming)
 ========================
+
+This update is mainly due to fixes in the data handling of the SARAH module. If you work with the SARAH data, we encourage you to update. 
+
 * Fixed compatibility with xarray v0.17.
 * Fixed sarah data for ``dx = dy = 0.05``. Due to the float32 dtype of the sarah coordinates, the cutout coordinates were corrupted when merging. This was fixed in the sarah module by converting the coordinates to float64. This also speeds up the cutout creation for more coarse grained cutouts.  
 * Fixed sarah data for a time frequency of 30 minutes. This was raising an assertion as is the (new) pandas frequency string for 30 minutes is '30T' not '30min'.
+* Fix the ``regrid`` function in ``atlite.gis`` for target coords which are not having the same bounds as the original ``xarray.Dataset``. The previous implementation was leading to a small shift of coordinates in the preparation of SARAH data (sorry for inconvenience).
+
+
 
 Version 0.2.1
 ==============

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,8 +10,8 @@ Release Notes
 
 Version 0.2.2 (upcoming)
 ========================
-* Fix compatibility with xarray v0.17.
-
+* Fixed compatibility with xarray v0.17.
+* Fixed sarah data for ``dx = dy = 0.05``. Due to the float32 dtype of the sarah coordinates, the cutout coordinates were corrupted when merging. This was fixed in the sarah module by converting the coordinates to float64. This also speeds up the cutout creation for more coarse grained cutouts.  
 
 Version 0.2.1
 ==============

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -178,6 +178,9 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
     ds_sid = xr.open_mfdataset(files.sid, combine='by_coords', **open_kwargs)
     ds = xr.merge([ds_sis, ds_sid])
     ds = ds.sel(lon=as_slice(coords['lon']), lat=as_slice(coords['lat']))
+    # fix float (im)precission
+    ds = ds.assign_coords(lon=ds.lon.astype(float).round(4),
+                          lat=ds.lat.astype(float).round(4))
 
     # Interpolate, resample and possible regrid
     if creation_parameters['sarah_interpolate']:

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -163,7 +163,7 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
         Dataset of dask arrays of the retrieved variables.
 
     """
-    assert cutout.dt in ("30min", 'h', 'H', '1h', '1H')
+    assert cutout.dt in ("30min", "30T", 'h', 'H', '1h', '1H')
 
     coords = cutout.coords
     chunks = cutout.chunks
@@ -188,7 +188,8 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
     else:
         ds = ds.fillna(0)
 
-    ds = ds if cutout.dt == '30min' else hourly_mean(ds)
+    if cutout.dt not in ['30min', '30T']:
+        ds = hourly_mean(ds)
     if (cutout.dx != dx) or (cutout.dy != dy):
         ds = regrid(ds, coords['lon'], coords['lat'], resampling=Resampling.average)
 

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -206,6 +206,25 @@ def cutout_sarah(tmp_path_factory):
     return cutout
 
 
+@pytest.fixture(scope='session')
+def cutout_sarah_fine(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("sarah_coarse")
+    cutout = Cutout(path=tmp_path / "sarah", module="sarah", bounds=BOUNDS,
+                    time=TIME, dx=0.05, dy=0.05, sarah_dir=SARAH_DIR)
+    cutout.prepare()
+    return cutout
+
+
+@pytest.fixture(scope='session')
+def cutout_sarah_weird(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("sarah_weird")
+    cutout = Cutout(path=tmp_path / "sarah", module="sarah", bounds=BOUNDS,
+                    time=TIME, dx=0.132, dy=0.32, sarah_dir=SARAH_DIR)
+    cutout.prepare()
+    return cutout
+
+
+
 
 
 
@@ -295,6 +314,28 @@ class TestERA5:
 @pytest.mark.skipif(not os.path.exists(SARAH_DIR),
                     reason="'sarah_dir' is not a valid path")
 class TestSarah:
+
+    @staticmethod
+    def test_all_non_na_sarah(cutout_sarah):
+        """Every cells should have data."""
+        assert np.isfinite(cutout_sarah.data).all()
+
+    @staticmethod
+    def test_all_non_na_sarah_fine(cutout_sarah_fine):
+        """Every cells should have data."""
+        assert np.isfinite(cutout_sarah_fine.data).all()
+
+    @staticmethod
+    def test_all_non_na_sarah_weird(cutout_sarah_weird):
+        """Every cells should have data."""
+        assert np.isfinite(cutout_sarah_weird.data).all()
+
+    @staticmethod
+    def test_dx_dy_preservation_sarah(cutout_sarah):
+        """The coordinates should be the same after preparation."""
+        assert np.allclose(np.diff(cutout_sarah.data.x), 0.25)
+        assert np.allclose(np.diff(cutout_sarah.data.y), 0.25)
+
 
     @staticmethod
     def test_prepared_features_sarah(cutout_sarah):


### PR DESCRIPTION
# Major fix for sarah data

* Fix the ``regrid`` function in ``atlite.gis`` for target coords which are not having the same bounds as the original ``xarray.Dataset``. The previous implementation was leading to a small shift of coordinates in the preparation of SARAH data.

* Fixed sarah data for a time frequency of 30 minutes. This was raising an assertion as is the (new) pandas frequency string for 30 minutes is '30T' not '30min'.

* Fixed sarah data for ``dx = dy = 0.05``. Due to the float32 dtype of the sarah coordinates, the cutout coordinates were corrupted when merging. This was fixed in the sarah module by converting the coordinates to float64. This also speeds up the cutout creation for more coarse grained cutouts.  

Additional tests were added.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- ~I have adjusted the docstrings in the code appropriately.~
- ~I have documented the effects of my code changes in the documentation `doc/`~.
- ~I have added newly introduced dependencies to `environment.yaml` file.~
- [x] I have added a note to release notes `doc/release_notes.rst`.
