### PR TITLE
add function for capacity layout

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,8 +10,9 @@ Release Notes
 
 Upcoming Release
 =================
-* The progressbar used in ``atlite.gis.availability_matrix`` is now a `tqdm` progressbar which displays better in parallel executions.
 
+* The progressbar used in ``atlite.gis.availability_matrix`` is now a `tqdm` progressbar which displays better in parallel executions.
+* The function ``layout_from_capacity_list`` was added to the cutout class. It is a convenience function that calculates the aggregated capacities per cutout grid cells (layout) based on a list of capacities with coordinates, e.g. list of wind turbines.    
 
 Version 0.2.2 
 ==============


### PR DESCRIPTION
The function ``layout_from_capacity_list`` was added to the cutout class. It calculates the aggregated capacities per cutout grid cells (layout) based on a list of capacities with coordinates, e.g. list of wind turbines.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
