### PR TITLE
Fix dask_kwrds being ignored during if only capacity_layout is created in convert_and_aggregate.

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,7 @@ Upcoming Release
 =================
 
 * Internal change: We are moving to `black` for internal code formatting.
+* Fix ignored keywords in convert_and_aggregate(...) for capacity_layout=True.
 
 Version 0.2.4 
 ==============

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -120,9 +120,9 @@ def convert_and_aggregate(
                 "given for `per_unit` or `return_capacity`"
             )
         if capacity_factor:
-            return maybe_progressbar(da.mean("time"), show_progress)
+            return maybe_progressbar(da.mean("time"), show_progress, **dask_kwargs)
         else:
-            return maybe_progressbar(da.sum("time"), show_progress)
+            return maybe_progressbar(da.sum("time"), show_progress, **dask_kwargs)
 
     if shapes is not None:
         geoseries_like = (pd.Series, gpd.GeoDataFrame, gpd.GeoSeries)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

This addresses the issue brought up by @lisazeyen off-list, where `atlite` did not consder restriction on the amount of threads used. The problem was caused by a missing passthrough of `dask_kwrds`.

## Change proposed in this Pull Request

Fix problem.

## Description
see summary above.

## Motivation and Context
No issue to link.

## How Has This Been Tested?
Not yet.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
