### PR TITLE
Add note to ExclusionContainer.add_raster(...) that anonymous (lambda) functions are not permitted.

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,7 @@ Release Notes
 Upcoming Release
 =================
 
+* Clarification for ``ExclusionContainer.add_raster(..)`` that ``codes=..`` does not accept ``lambda``-functions in combination with ``multiprocessing``.
 * Internal change: We are moving to `black` for internal code formatting.
 * Fix ignored keywords in convert_and_aggregate(...) for capacity_layout=True.
 

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -195,7 +195,9 @@ class ExclusionContainer:
         codes : int/list/function, optional
             Codes in the raster which to exclude. Can be a callable function
             which takes the mask (np.array) as argument and performs a
-            elementwise condition (must not change the shape). The default is 1.
+            elementwise condition (must not change the shape). The function may
+            not be an anonymous (lambda) function.
+            The default is 1.
         buffer : int, optional
             Buffer around the excluded areas in units of ExclusionContainer.crs.
             Use this to create a buffer around the excluded/included area.

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -19,6 +19,7 @@ import xarray as xr
 import numpy as np
 import rasterio as rio
 import rasterio.warp
+import functools
 from atlite import Cutout
 from atlite.gis import ExclusionContainer, shape_availability, pad_extent, regrid
 from shapely.geometry import box
@@ -257,18 +258,19 @@ def test_availability_matrix_flat_parallel(ref):
     assert np.allclose(I, ds.sum("shape"))
 
 
-# def test_availability_matrix_flat_parallel_anonymous_function(ref, raster_codes):
-#     """
-#     Test availability matrix in parallel mode with a anonymous filter function.
-#     """
-#     shapes = gpd.GeoSeries(
-#         [box(X0 + 1, Y0 + 1, X1 - 1, Y1 - 1)], crs=ref.crs
-#     ).rename_axis("shape")
-#     I = ref.indicatormatrix(shapes).sum(0).reshape(ref.shape)
-#     I = xr.DataArray(I, coords=[ref.coords["y"], ref.coords["x"]])
-#     excluder = ExclusionContainer(ref.crs, res=0.01)
-#     excluder.add_raster(raster_codes, codes=lambda x: x < 20, invert=True)
-#     ref.availabilitymatrix(shapes, excluder, nprocesses=2)
+def test_availability_matrix_flat_parallel_anonymous_function(ref, raster_codes):
+    """
+    Test availability matrix in parallel mode with a non-anonymous filter function.
+    """
+    shapes = gpd.GeoSeries(
+        [box(X0 + 1, Y0 + 1, X1 - 1, Y1 - 1)], crs=ref.crs
+    ).rename_axis("shape")
+    I = ref.indicatormatrix(shapes).sum(0).reshape(ref.shape)
+    I = xr.DataArray(I, coords=[ref.coords["y"], ref.coords["x"]])
+    excluder = ExclusionContainer(ref.crs, res=0.01)
+    func = functools.partial(np.greater_equal, 20)
+    excluder.add_raster(raster_codes, codes=func)
+    ref.availabilitymatrix(shapes, excluder, nprocesses=2)
 
 
 def test_availability_matrix_flat_wo_progressbar(ref):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Change proposed in this Pull Request
Doc-string change for `ExclusionContainer.add_raster(...)` and changes to tests:
Anonymous functions are not permitted for the `codes=...` keyword argument.

## Description
Non-anonymous functions can be used. As an example I've changed the related test (which was for the meantime inactive) from a lambda function to an equivalent formulation using `functools.partial` and `np.greater_equal`.


## Motivation and Context
Anonymous functions lead to complications with python's `multiprocessing`, c.f. https://github.com/PyPSA/pypsa-eur/issues/249 .

## How Has This Been Tested?
n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [n/a ] New feature (non-breaking change which adds functionality)
- [n/a] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [n/a] I have documented the effects of my code changes in the documentation `doc/`.
- [n/a] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
