### PR TITLE
ERA5: rename "orography" variable to "geopotential"

### DIFF
--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -181,7 +181,7 @@ def sanitize_runoff(ds):
 
 def get_data_height(retrieval_params):
     """Get height data for given retrieval parameters."""
-    ds = retrieve_data(variable="orography", **retrieval_params)
+    ds = retrieve_data(variable="geopotential", **retrieval_params)
 
     ds = _rename_and_clean_coords(ds)
     ds = _add_height(ds)

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -242,7 +242,7 @@ def hydro_test(cutout):
 
 
 TIME = "2013-01-01"
-BOUNDS = (-4, 56, 1.5, 61)
+BOUNDS = (-4, 56, 1.5, 62)
 SARAH_DIR = os.getenv("SARAH_DIR", "/home/vres/climate-data/sarah_v2")
 GEBCO_PATH = os.getenv("GEBCO_PATH", "/home/vres/climate-data/GEBCO_2014_2D.nc")
 


### PR DESCRIPTION
## Change proposed in this Pull Request

Change the cds variable name "orography" to "geopotential". 
According to https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation "orography" is a valid variable name, but in the cdsapi it returns no data error. This might be a temporary thing due to problems on the era5 server. It didn't raise an error so far, as the cutouts of the test scripts were "kept warm" by the cds server.  

Note: if the problem resolves automatically, I'd say we kill this PR, but if not, it provides remedy.   

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
