### PR TITLE
add notice about processing time CDS

### DIFF
--- a/examples/create_cutout.ipynb
+++ b/examples/create_cutout.ipynb
@@ -68,22 +68,16 @@
     "\n",
     "The `cutout` is created in the directory and file specified by the relative `path`\n",
     "If a cutout at the given location already exists, then this command will simply load the cutout again.\n",
-    "If the cutout does not yet exist, it will specify the new to-be-created cutout."
+    "If the cutout does not yet exist, it will specify the new to-be-created cutout.\n",
+    "> **Note** `ERA5`, Before the data can be downloaded it has to be processed by CDS servers, this might take a while depending on the ammout of data requested. \n",
+    "You can check the status of your request [here](https://cds.climate.copernicus.eu/cdsapp#!/yourrequests)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:atlite.cutout:Building new cutout western-europe-2011-01.nc\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cutout = atlite.Cutout(path=\"western-europe-2011-01.nc\",\n",
     "                       module=\"era5\",\n",

--- a/examples/create_cutout.ipynb
+++ b/examples/create_cutout.ipynb
@@ -75,9 +75,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:atlite.cutout:Building new cutout western-europe-2011-01.nc\n"
+     ]
+    }
+   ],
    "source": [
     "cutout = atlite.Cutout(path=\"western-europe-2011-01.nc\",\n",
     "                       module=\"era5\",\n",

--- a/examples/create_cutout.ipynb
+++ b/examples/create_cutout.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->


## Change proposed in this Pull Request
Added a notice about the  CDS side processing time in the create_cutout example including a link where to 
check the status of CDS request. To inform about why it might take a while before the download starts.
<!--- Provide a general, short summary of your changes in the title above -->

## Motivation and Context
Motivated by #175

