### PR TITLE
doc: fix css overwriting file

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,12 +155,13 @@ html_theme_options = {
 }
 
 
-# Add any paths that contain custom themes here, relative to this directory.
+# These folders are copied to the documentation's HTML output
 html_static_path = ["_static"]
 
-html_context = {
-    "css_files": ["_static/theme_overrides.css"]  # override wide tables in RTD theme
-}
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = ["theme_overrides.css"]
+
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
fix error in the css file configuration due to incompatibility with new version of sphinx-rtd-theme 