### PR TITLE
Explicit units and meaning of returned DataArrays

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,7 @@ Release Notes
 .. =================
 
 * Automated upload of code coverage reports via Codecov.
+* DataArrays returned by `.pv(...)` and `.wind(...)` now have a clearer name and 'units' attribute.
 
 Version 0.2.5 
 ==============

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -125,7 +125,7 @@ def convert_and_aggregate(
             return maybe_progressbar(res, show_progress, **dask_kwargs)
         else:
             res = da.sum("time", keep_attrs=True)
-            return maybe_progressbar(res,  show_progress, **dask_kwargs)
+            return maybe_progressbar(res, show_progress, **dask_kwargs)
 
     if shapes is not None:
         geoseries_like = (pd.Series, gpd.GeoDataFrame, gpd.GeoSeries)

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -124,9 +124,8 @@ def convert_and_aggregate(
             res.attrs["units"] = "p.u."
             return maybe_progressbar(res, show_progress, **dask_kwargs)
         else:
-            return maybe_progressbar(
-                da.sum("time", keep_attrs=True), show_progress, **dask_kwargs
-            )
+            res = da.sum("time", keep_attrs=True)
+            return maybe_progressbar(res,  show_progress, **dask_kwargs)
 
     if shapes is not None:
         geoseries_like = (pd.Series, gpd.GeoDataFrame, gpd.GeoSeries)

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -120,11 +120,9 @@ def convert_and_aggregate(
                 "given for `per_unit` or `return_capacity`"
             )
         if capacity_factor:
-            return maybe_progressbar(
-                da.mean("time").assign_attrs(units="p.u.").rename("capacity factor"),
-                show_progress,
-                **dask_kwargs,
-            )
+            res = da.mean("time").rename("capacity factor")
+            res.attrs["units"] = "p.u."
+            return maybe_progressbar(res, show_progress, **dask_kwargs)
         else:
             return maybe_progressbar(
                 da.sum("time", keep_attrs=True), show_progress, **dask_kwargs

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -41,7 +41,11 @@ def _power_huld(irradiance, t_amb, pc):
 
     eff = eff.fillna(0.0).clip(min=0)
 
-    return G_ * eff * pc.get("inverter_efficiency", 1.0)
+    da = G_ * eff * pc.get("inverter_efficiency", 1.0)
+    da.attrs["units"] = "kWh/kWp"
+    da = da.rename("specific generation")
+
+    return da
 
 
 def _power_bofinger(irradiance, t_amb, pc):

--- a/atlite/resources/solarpanel/CSi.yaml
+++ b/atlite/resources/solarpanel/CSi.yaml
@@ -17,7 +17,7 @@ c_temp_irrad: 0.035 # 0.035 K / (W/m2)
 # Reference conditions
 r_tamb: 293 # 20 degC
 r_tmod: 298 # 25 degC
-r_irradiance: 1000 # W
+r_irradiance: 1000 # W/m^2
 
 # Fitting parameters
 k_1: -0.017162

--- a/atlite/resources/solarpanel/CdTe.yaml
+++ b/atlite/resources/solarpanel/CdTe.yaml
@@ -17,7 +17,7 @@ c_temp_irrad: 0.035 # 35 degC / (W/m2)
 # Reference conditions
 r_tamb: 293 # 20 degC
 r_tmod: 298 # 25 degC
-r_irradiance: 1000 # W
+r_irradiance: 1000 # W/m^2
 
 # Fitting parameters
 k_1: -0.103251


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

I'm not 100% satisfied with the PR, it feels a bit hacky. Nevertheless...

## Change proposed in this Pull Request

Explicitly provide units and a name for returned DataArrays created by `.wind(...)` and `.pv(...)` function.

## Description

For `.wind(...)` the location to set name and unit is straightforward.
For `.pv(...)` I'm not an expert for the Boilfinger model and couldn't find the correct location; I would assume the unit is identical to the Huld model, but since I am not 100% sure I decide to set unit and name inside the specific model.

Inside `.convert_and_aggregate(...)` where the DataArrays are manipulated the unit/name are either changed or keeping of the attributes is made explicit via `keep_attrs=True` (otherwise they would be implicitly removed by `xarray`).

Caveat: Setting of units relies on some conventions, e.g. for the units assumed in the panelconfig and turbineconfig files. However the code already makes these assumptions, so it is not a new hard-coded reliance that is introduced.

## Motivation and Context

Units until now were not made explicit for these cases and confusing.

## How Has This Been Tested?
Local testing.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
