### PR TITLE
Adress future warning for SARAH cutout creation.

### DIFF
--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -69,7 +69,7 @@ def get_filenames(sarah_dir, coords):
     start = coords["time"].to_index()[0]
     end = coords["time"].to_index()[-1]
 
-    if (start < files.index[0]) or (end.date() > files.index[-1]):
+    if (start < files.index[0]) or (end > files.index[-1]):
         logger.error(
             f"Files in {sarah_dir} do not cover the whole time span:"
             f"\n\t{start} until {end}"


### PR DESCRIPTION
## Change proposed in this Pull Request

Cutout creation with SARAH yields the following warning:

```
atlite/atlite/datasets/sarah.py:72: FutureWarning: Comparison of Timestamp with datetime.date is deprecated in order to match the standard library behavior.  In a future version these will be considered non-comparable.Use 'ts == pd.Timestamp(date)' or 'ts.date() == date' instead.
  if (start < files.index[0]) or (end.date() > files.index[-1]):
```

This is adressed by this PR.

## Description

remove `.date()` from comparison which doesn't seem to be needed anyways, as timestamps are compared.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
