### PR TITLE
Calculate solar position already during cutout creation + add time-shift for ERA5

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -14,10 +14,15 @@ Release Notes
 * Atlite now supports calculating dynamic line ratings based on the IEEE-738 standard (https://github.com/PyPSA/atlite/pull/189).
 * The wind feature provided by ERA5 now also calculates the wind angle `wnd_azimuth` in range [0 - 2π) spanning the cirlce from north in clock-wise direction (0 is north, π/2 is east, -π is south, 3π/2 is west).
 * A new intersection matrix function was added, which works similarly to incidence matrix but has boolean values.
-
+* The solar position (azimuth and altitude) are now part of the cutout feature `influx`. Cutouts created with earlier versions will become incompatible with the next major.
 
 * Automated upload of code coverage reports via Codecov.
 * DataArrays returned by `.pv(...)` and `.wind(...)` now have a clearer name and 'units' attribute.
+
+**Bug fixes**
+* The solar position for ERA5 cutouts is now calculated for half a time step earlier (time-shift by `cutout.dt/2`) to account for the aggregated nature of
+  ERA5 variables (see https://github.com/PyPSA/atlite/issues/158). The fix is only applied to newly created cutouts. Previously created cutouts do not profit
+  from this fix and need to be recreated `cutout.prepare(overwrite=True)`.
 
 Version 0.2.5 
 ==============

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -163,7 +163,15 @@ def get_data_influx(retrieval_params):
         warnings.simplefilter("ignore", DeprecationWarning)
         # Convert dt / time frequency to timedelta and shift solar position by half
         # (freqs like ["H","30T"] do not work with pd.to_timedelta(...)
-        time_shift = -1 / 2 * pd.to_timedelta(pd.date_range('1970-01-01', periods=1, freq=pd.infer_freq(ds["time"])).freq)
+        time_shift = (
+            -1
+            / 2
+            * pd.to_timedelta(
+                pd.date_range(
+                    "1970-01-01", periods=1, freq=pd.infer_freq(ds["time"])
+                ).freq
+            )
+        )
         sp = SolarPosition(ds, time_shift=time_shift)
     sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2016-2019 The Atlite Authors
+# SPDX-FileCopyrightText: 2016-2021 The Atlite Authors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -12,6 +12,7 @@ https://confluence.ecmwf.int/display/CKB/ERA5%3A+data+documentation
 """
 
 import os
+import warnings
 import numpy as np
 import xarray as xr
 from tempfile import mkstemp
@@ -156,7 +157,10 @@ def get_data_influx(retrieval_params):
     # ERA5 variables are mean values for previous hour, i.e. 13:01 to 14:00 are labelled as "14:00"
     # account by calculating the SolarPosition for the center of the interval for aggregation happens
     # see https://github.com/PyPSA/atlite/issues/158
-    sp = SolarPosition(ds, time_shift="-30min")
+    # Do not show DeprecationWarning from new SolarPosition calculation (#199)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore",DeprecationWarning)
+        sp = SolarPosition(ds, time_shift="-30min")
     sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 
     ds = xr.merge([ds, sp])

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -42,7 +42,15 @@ crs = 4326
 features = {
     "height": ["height"],
     "wind": ["wnd100m", "wnd_azimuth", "roughness"],
-    "influx": ["influx_toa", "influx_direct", "influx_diffuse", "albedo", "solar_position: altitude", "solar_position: azimuth", "solar_position: atmospheric insolation"],
+    "influx": [
+        "influx_toa",
+        "influx_direct",
+        "influx_diffuse",
+        "albedo",
+        "solar_position: altitude",
+        "solar_position: azimuth",
+        "solar_position: atmospheric insolation",
+    ],
     "temperature": ["temperature", "soil temperature"],
     "runoff": ["runoff"],
 }
@@ -149,9 +157,9 @@ def get_data_influx(retrieval_params):
     # account by calculating the SolarPosition for the center of the interval for aggregation happens
     # see https://github.com/PyPSA/atlite/issues/158
     sp = SolarPosition(ds, time_shift="-30min")
-    sp = sp.rename({v:f"solar_position: {v}" for v in sp.data_vars})
+    sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 
-    ds = xr.merge([ds,sp])
+    ds = xr.merge([ds, sp])
 
     return ds
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -164,8 +164,8 @@ def get_data_influx(retrieval_params):
     return ds
 
 
-def sanitize_inflow(ds):
-    """Sanitize retrieved inflow data."""
+def sanitize_influx(ds):
+    """Sanitize retrieved influx data."""
     for a in ("influx_direct", "influx_diffuse", "influx_toa"):
         ds[a] = ds[a].clip(min=0.0)
     return ds

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -159,7 +159,7 @@ def get_data_influx(retrieval_params):
     # see https://github.com/PyPSA/atlite/issues/158
     # Do not show DeprecationWarning from new SolarPosition calculation (#199)
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore",DeprecationWarning)
+        warnings.simplefilter("ignore", DeprecationWarning)
         sp = SolarPosition(ds, time_shift="-30min")
     sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2016-2019 The Atlite Authors
+# SPDX-FileCopyrightText: 2016-2021 The Atlite Authors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -12,6 +12,7 @@ from ..gis import regrid
 from ..pv.solar_position import SolarPosition
 from rasterio.warp import Resampling
 import os
+import warnings
 import glob
 import pandas as pd
 import numpy as np
@@ -224,7 +225,10 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
 
     ds = ds.swap_dims({"lon": "x", "lat": "y"})
 
-    sp = SolarPosition(ds, time_shift="0H")
+    # Do not show DeprecationWarning from new SolarPosition calculation (#199)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore",DeprecationWarning)
+        sp = SolarPosition(ds, time_shift="0H")
     sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 
     ds = xr.merge([ds, sp])

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -227,7 +227,7 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
 
     # Do not show DeprecationWarning from new SolarPosition calculation (#199)
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore",DeprecationWarning)
+        warnings.simplefilter("ignore", DeprecationWarning)
         sp = SolarPosition(ds, time_shift="0H")
     sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -28,7 +28,15 @@ crs = 4326
 dx = 0.05
 dy = 0.05
 dt = "30min"
-features = {"influx": ["influx_direct", "influx_diffuse", "solar_position: altitude", "solar_position: azimuth", "solar_position: atmospheric insolation"]}
+features = {
+    "influx": [
+        "influx_direct",
+        "influx_diffuse",
+        "solar_position: altitude",
+        "solar_position: azimuth",
+        "solar_position: atmospheric insolation",
+    ]
+}
 static_features = {}
 
 
@@ -217,8 +225,8 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
     ds = ds.swap_dims({"lon": "x", "lat": "y"})
 
     sp = SolarPosition(ds, time_shift="0H")
-    sp = sp.rename({v:f"solar_position: {v}" for v in sp.data_vars})
+    sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
 
-    ds = xr.merge([ds,sp])
+    ds = xr.merge([ds, sp])
 
     return ds

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -22,7 +22,7 @@ def SolarPosition(ds, time_shift="0H"):
     ----------
     ds: xr.DataSet
         DataSet for which the solar positions are calculated.
-    time_shift: str (optional)
+    time_shift: str or pandas.TimeDelta (optional)
         Time shift to apply before the solar position calculations. Useful
         for datasets representing aggregate data (e.g. ERA5) instead of
         instantenous data (e.g. SARAH). Must be parseable by pandas.to_timedelta().

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -52,7 +52,7 @@ def SolarPosition(ds, time_shift="0H"):
 
     """
 
-    # Act like a getter if these return variables are already in ds 
+    # Act like a getter if these return variables are already in ds
     rvs = {
         "solar_position: azimuth",
         "solar_position: altitude",

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2016-2019 The Atlite Authors
+# SPDX-FileCopyrightText: 2016-2021 The Atlite Authors
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -8,6 +8,8 @@ from numpy import pi
 import xarray as xr
 from numpy import sin, cos, arcsin, arccos, arctan2, deg2rad
 import pandas as pd
+from warnings import warn
+
 
 def SolarPosition(ds, time_shift="0H"):
     """
@@ -50,17 +52,38 @@ def SolarPosition(ds, time_shift="0H"):
 
     """
 
+    # Act like a getter if these return variables are already in ds 
+    rvs = {
+        "solar_position: azimuth",
+        "solar_position: altitude",
+        "solar_position: atmospheric insolation",
+    }
+
+    if rvs.issubset(set(ds.data_vars)):
+        solar_position = ds[rvs]
+        solar_position = solar_position.rename(
+            {v: v.replace("solar_position: ", "") for v in rvs}
+        )
+        return solar_position
+
+    warn(
+        """The calculation method and handling of solar position variables will change.
+    The solar position will in the future be a permanent variables of a cutout.
+    Recreate your cutout to remove this warning and permanently include the solar position variables into your cutout.""",
+        DeprecationWarning,
+    )
+
     # up to h and dec from [1]
 
     time_shift = pd.to_timedelta(time_shift)
 
-    t = ds.indexes["time"] - time_shift
+    t = ds.indexes["time"] + time_shift
     n = xr.DataArray(t.to_julian_date(), coords=ds["time"].coords) - 2451545.0
-    hour = (ds["time"] - time_shift).dt.hour
-    minute = (ds["time"] - time_shift).dt.minute
+    hour = (ds["time"] + time_shift).dt.hour
+    minute = (ds["time"] + time_shift).dt.minute
 
     # Operations make new DataArray eager; reconvert to lazy dask arrays
-    chunks = ds.chunksizes.get("time","auto")
+    chunks = ds.chunksizes.get("time", "auto")
     n = n.chunk(chunks)
     hour = hour.chunk(chunks)
     minute = minute.chunk(chunks)
@@ -83,8 +106,10 @@ def SolarPosition(ds, time_shift="0H"):
     # Clip before arcsin to prevent values < -1. from rounding errors; can
     # cause NaNs later
     alt = arcsin(
-        (sin(lat) * sin(dec) + cos(lat) * cos(dec) * cos(h)).clip(min=-1.0, max=1.0)
+        (sin(dec) * sin(lat) + cos(dec) * cos(lat) * cos(h)).clip(min=-1.0, max=1.0)
     ).rename("altitude")
+    alt.attrs["time shift"] = f"{time_shift}"
+    alt.attrs["units"] = "rad"
 
     az = arccos(
         ((sin(dec) * cos(lat) - cos(dec) * sin(lat) * cos(h)) / cos(alt)).clip(
@@ -92,6 +117,8 @@ def SolarPosition(ds, time_shift="0H"):
         )
     )
     az = az.where(h <= 0, 2 * pi - az).rename("azimuth")
+    az.attrs["time shift"] = f"{time_shift}"
+    az.attrs["units"] = "rad"
 
     if "influx_toa" in ds:
         atmospheric_insolation = ds["influx_toa"].rename("atmospheric insolation")
@@ -100,6 +127,8 @@ def SolarPosition(ds, time_shift="0H"):
         atmospheric_insolation = (1366.1 * (1 + 0.033 * cos(g)) * sin(alt)).rename(
             "atmospheric insolation"
         )
+        atmospheric_insolation.attrs["time shift"] = f"{time_shift}"
+        atmospheric_insolation.attrs["units"] = "W m**-2"
 
     vars = {da.name: da for da in [alt, az, atmospheric_insolation]}
     solar_position = xr.Dataset(vars)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #158 .

## Change proposed in this Pull Request

* Solar position will be calculated during cutout creation
* `atlite.pv.solar_position.SolarPosition` results become part of the `"influx"` feature
* Solar position for ERA5 is calculated with an time-shift of "-30min" to take into account the fact that ERA5 variables are aggregated (right interval border, see #158 )
* `atlite.pv.solar_position.SolarPosition(...)` is backwards compatible (for now) and acts as a pure getter if the variables are present in the cutout, else it calculates them.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested locally on two cutouts (one ERA5, one SARAH)

![image](https://user-images.githubusercontent.com/42553970/143131854-b923d852-4a5f-48a2-8c81-2a0b876278e6.png)


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [ ] ~I have documented the effects of my code changes in the documentation `doc/`.~
- [ ] ~I have added newly introduced dependencies to `environment.yaml` file.~
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution

## TODOs

- [x] Release notes
- [x] Suppress deprecation warning during cutout creation
