### PR TITLE
correct equation natural convection

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -895,7 +895,7 @@ def convert_line_rating(
     qcf = np.maximum(qcf1, qcf2)
 
     #  natural convection
-    qcn = 3.645 * rho * D ** 0.75 * Tdiff ** 1.25
+    qcn = 3.645 * np.sqrt(rho) * D ** 0.75 * Tdiff ** 1.25
 
     # convection loss is the max between forced and natural
     qc = np.maximum(qcf, qcn)


### PR DESCRIPTION
There is a small mistake in the natural convection equation. It is supposed to be the square root of rho. 
![image](https://user-images.githubusercontent.com/95913147/151507682-6b21e04c-1ce5-43cd-becb-673d20bfdad2.png)
