### PR TITLE
Fix degree to radian in latitude and latitude_optimal in orientation module

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -27,6 +27,7 @@ Release Notes
 * The solar position for ERA5 cutouts is now calculated for half a time step earlier (time-shift by `cutout.dt/2`) to account for the aggregated nature of
   ERA5 variables (see https://github.com/PyPSA/atlite/issues/158). The fix is only applied to newly created cutouts. Previously created cutouts do not profit
   from this fix and need to be recreated `cutout.prepare(overwrite=True)`.
+* The functions `make_latitude` and `make_latitude_optimal` were not converting degrees to radian correctly. This resulted in a wrong calculation of the power output when using the orientation `latitude_optimal` or `latitude` in the `pv` conversion function. We are sorry for inconveniences.   
 
 
 Version 0.2.5 

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -7,7 +7,7 @@
 import sys
 import numpy as np
 import xarray as xr
-from numpy import sin, cos, deg2rad
+from numpy import sin, cos, deg2rad, pi
 
 
 def get_orientation(name, **params):
@@ -60,7 +60,7 @@ def make_latitude_optimal():
         slope[~below_50] = np.deg2rad(40.0)
 
         # South orientation for panels on northern hemisphere and vice versa
-        azimuth = np.where(lat.values < 0, 0, 180)
+        azimuth = np.where(lat.values < 0, 0, pi)
 
         return dict(
             slope=xr.DataArray(slope, coords=lat.coords),
@@ -81,6 +81,8 @@ def make_constant(slope, azimuth):
 
 
 def make_latitude(azimuth=180):
+    azimuth = deg2rad(azimuth)
+
     def latitude(lon, lat, solar_position):
         return dict(slope=lat, azimuth=azimuth)
 


### PR DESCRIPTION
The current implementation does not convert degrees to radian in the `make_latitude` and `make_latitude_optimal` function. This fixes it. 

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have added a note to release notes `doc/release_notes.rst`.
