### PR TITLE
orientation: add horizontal single axis tracking

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,6 +22,7 @@ Release Notes
 * Due to ambiguity, conversion functions (`.pv(...)`, `.wind(...)` etc.) now raise an `ValueError` if shapes and matrix are given. 
 * Atlite now supports calculating of heat pump coefficients of performance (https://github.com/PyPSA/atlite/pull/145).
 * Enabled the GitHub feature "Cite this repository" to generate a BibTeX file (Added a `CITATION.cff` file to the repository).
+* Atlite now supports calculating PV potentials with a Horizontal Single Axis Tracker (HSAT). The method can be activated setting the `orientation="hsat"` in the `pv` conversion function.    
 
 **Bug fixes**
 * The solar position for ERA5 cutouts is now calculated for half a time step earlier (time-shift by `cutout.dt/2`) to account for the aggregated nature of

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -37,7 +37,7 @@ def make_hsat():
         slope = np.pi / 2 - np.abs(solar_position["altitude"])
 
         # South orientation for panels on northern hemisphere and vice versa
-        azimuth = np.where(solar_position["azimuth"]< np.pi, np.pi / 2, 3 * np.pi / 2)
+        azimuth = np.where(solar_position["azimuth"] < np.pi, np.pi / 2, 3 * np.pi / 2)
 
         return dict(
             slope=slope,

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -34,15 +34,14 @@ def make_hsat():
 
     def horizontal_tracking(lon, lat, solar_position):
 
-        altitude = solar_position.altitude
-        slope = np.pi / 2 - np.abs(altitude)
+        slope = np.pi / 2 - np.abs(solar_position["altitude"])
 
         # South orientation for panels on northern hemisphere and vice versa
-        azimuth = np.where(solar_position.azimuth < np.pi, pi / 2, 3 * pi / 2)
+        azimuth = np.where(solar_position["azimuth"]< np.pi, np.pi / 2, 3 * np.pi / 2)
 
         return dict(
             slope=slope,
-            azimuth=xr.DataArray(azimuth, coords=altitude.coords),
+            azimuth=xr.DataArray(azimuth, coords=solar_position["altitude"].coords),
         )
 
     return horizontal_tracking

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -23,6 +23,31 @@ def get_orientation(name, **params):
     return getattr(sys.modules[__name__], "make_{}".format(name))(**params)
 
 
+def make_hsat():
+    """
+    Returns a function mimicing a Horizontal Single Axis Tracker (HSAT).
+
+    The method sets the east-west tilt of the PV panel perpendicular to the
+    solar altitude. The axis of rotation is horizontal with respect to the
+    ground.
+    """
+
+    def horizontal_tracking(lon, lat, solar_position):
+
+        altitude = solar_position.altitude
+        slope = np.pi / 2 - np.abs(altitude)
+
+        # South orientation for panels on northern hemisphere and vice versa
+        azimuth = np.where(solar_position.azimuth < np.pi, pi / 2, 3 * pi / 2)
+
+        return dict(
+            slope=slope,
+            azimuth=xr.DataArray(azimuth, coords=altitude.coords),
+        )
+
+    return horizontal_tracking
+
+
 def make_latitude_optimal():
     """
     Returns an optimal tilt angle for the given ``lat``, assuming that

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -132,6 +132,17 @@ def pv_test(cutout):
     # should be roughly the same
     assert (production_other.sum() / production_opt.sum()).round(0) == 1
 
+    # now use horizontal tracking
+    production_hsat = cutout.pv(
+        atlite.resource.solarpanels.CdTe,
+        "hsat",
+        layout=cap_factor_opt,
+    )
+
+    assert production_hsat.sel(time=TIME + " 00:00") == 0
+    # should be lower since it's winter
+    assert (production_hsat.sum() / production_opt.sum()) < 1
+
 
 def csp_test(cutout):
     """


### PR DESCRIPTION
Related to #140 

Test is with 
```
import atlite
import pandas as pd

cutout = atlite.Cutout('test.nc', time='2019-05-30', x=slice(10,12), y=slice(40,42), module='era5')
cutout.prepare()

layout = cutout.uniform_layout()
panel = atlite.solarpanels.CSi

orientations = ['hsat', 'latitude_optimal', dict(slope=30, azimuth=180)]
ds = []
for orientation in orientations:
    ds.append(cutout.pv(panel, orientation, layout=layout).squeeze().to_pandas())

pd.concat(ds, keys=[str(k) for k in orientations], axis=1).plot()

```

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
