### PR TITLE
purge influx feature 

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,6 +22,7 @@ Release Notes
 * Due to ambiguity, conversion functions (`.pv(...)`, `.wind(...)` etc.) now raise an `ValueError` if shapes and matrix are given. 
 * Atlite now supports calculating of heat pump coefficients of performance (https://github.com/PyPSA/atlite/pull/145).
 * Enabled the GitHub feature "Cite this repository" to generate a BibTeX file (Added a `CITATION.cff` file to the repository).
+* The function `SolarPosition` does not return the atmospheric insolation anymore. This data variable was not used by any of the currently supported modules. 
 
 **Bug fixes**
 * The solar position for ERA5 cutouts is now calculated for half a time step earlier (time-shift by `cutout.dt/2`) to account for the aggregated nature of

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -909,9 +909,7 @@ def convert_line_rating(
 
     if isinstance(ds, dict):
         Position = namedtuple("solarposition", ["altitude", "azimuth"])
-        solar_position = Position(
-            ds["solar_position: altitude"], ds["solar_position: azimuth"]
-        )
+        solar_position = Position(ds["solar_altitude"], ds["solar_azimuth"])
     else:
         solar_position = SolarPosition(ds)
     Phi_s = np.arccos(

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -49,9 +49,8 @@ features = {
         "influx_direct",
         "influx_diffuse",
         "albedo",
-        "solar_position: altitude",
-        "solar_position: azimuth",
-        "solar_position: atmospheric insolation",
+        "solar_altitude",
+        "solar_azimuth",
     ],
     "temperature": ["temperature", "soil temperature"],
     "runoff": ["runoff"],
@@ -173,7 +172,7 @@ def get_data_influx(retrieval_params):
             )
         )
         sp = SolarPosition(ds, time_shift=time_shift)
-    sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
+    sp = sp.rename({v: f"solar_{v}" for v in sp.data_vars})
 
     ds = xr.merge([ds, sp])
 

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -33,10 +33,9 @@ features = {
     "influx": [
         "influx_direct",
         "influx_diffuse",
-        "solar_position: altitude",
-        "solar_position: azimuth",
-        "solar_position: atmospheric insolation",
-    ]
+        "solar_altitude",
+        "solar_azimuth",
+    ],
 }
 static_features = {}
 
@@ -229,7 +228,7 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         sp = SolarPosition(ds, time_shift="0H")
-    sp = sp.rename({v: f"solar_position: {v}" for v in sp.data_vars})
+    sp = sp.rename({v: f"solar_{v}" for v in sp.data_vars})
 
     ds = xr.merge([ds, sp])
 

--- a/atlite/pv/irradiation.py
+++ b/atlite/pv/irradiation.py
@@ -20,7 +20,7 @@ def DiffuseHorizontalIrrad(ds, solar_position, clearsky_model, influx):
     # Lauret et al. (2013):http://dx.doi.org/10.1016/j.renene.2012.01.049
 
     sinaltitude = sin(solar_position["altitude"])
-    atmospheric_insolation = solar_position["atmospheric insolation"]
+    influx_toa = ds["influx_toa"]
 
     if clearsky_model is None:
         clearsky_model = (
@@ -29,7 +29,7 @@ def DiffuseHorizontalIrrad(ds, solar_position, clearsky_model, influx):
 
     # Reindl 1990 clearsky model
 
-    k = influx / atmospheric_insolation  # clearsky index
+    k = influx / influx_toa  # clearsky index
     # k.values[k.values > 1.0] = 1.0
     # k = k.rename('clearsky index')
 
@@ -82,7 +82,7 @@ def TiltedDiffuseIrrad(ds, solar_position, surface_orientation, direct, diffuse)
     # Hay-Davies Model
 
     sinaltitude = sin(solar_position["altitude"])
-    atmospheric_insolation = solar_position["atmospheric insolation"]
+    influx_toa = ds["influx_toa"]
 
     cosincidence = surface_orientation["cosincidence"]
     surface_slope = surface_orientation["slope"]
@@ -94,7 +94,7 @@ def TiltedDiffuseIrrad(ds, solar_position, surface_orientation, direct, diffuse)
         f = sqrt(direct / influx).fillna(0.0)
 
         # anisotropy factor
-        A = direct / atmospheric_insolation
+        A = direct / influx_toa
 
     # geometric factor
     R_b = cosincidence / sinaltitude
@@ -159,7 +159,7 @@ def TiltedIrradiation(
     altitude_threshold=1.0,
 ):
 
-    influx_toa = solar_position["atmospheric insolation"]
+    influx_toa = ds["influx_toa"]
 
     def clip(influx, influx_max):
         # use .data in clip due to dask-xarray incompatibilities

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -54,15 +54,14 @@ def SolarPosition(ds, time_shift="0H"):
 
     # Act like a getter if these return variables are already in ds
     rvs = {
-        "solar_position: azimuth",
-        "solar_position: altitude",
-        "solar_position: atmospheric insolation",
+        "solar_azimuth",
+        "solar_altitude",
     }
 
     if rvs.issubset(set(ds.data_vars)):
         solar_position = ds[rvs]
         solar_position = solar_position.rename(
-            {v: v.replace("solar_position: ", "") for v in rvs}
+            {v: v.replace("solar_: ", "") for v in rvs}
         )
         return solar_position
 
@@ -120,17 +119,7 @@ def SolarPosition(ds, time_shift="0H"):
     az.attrs["time shift"] = f"{time_shift}"
     az.attrs["units"] = "rad"
 
-    if "influx_toa" in ds:
-        atmospheric_insolation = ds["influx_toa"].rename("atmospheric insolation")
-    else:
-        # [3]
-        atmospheric_insolation = (1366.1 * (1 + 0.033 * cos(g)) * sin(alt)).rename(
-            "atmospheric insolation"
-        )
-        atmospheric_insolation.attrs["time shift"] = f"{time_shift}"
-        atmospheric_insolation.attrs["units"] = "W m**-2"
-
-    vars = {da.name: da for da in [alt, az, atmospheric_insolation]}
+    vars = {da.name: da for da in [alt, az]}
     solar_position = xr.Dataset(vars)
 
     return solar_position

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -61,7 +61,7 @@ def SolarPosition(ds, time_shift="0H"):
     if rvs.issubset(set(ds.data_vars)):
         solar_position = ds[rvs]
         solar_position = solar_position.rename(
-            {v: v.replace("solar_: ", "") for v in rvs}
+            {v: v.replace("solar_", "") for v in rvs}
         )
         return solar_position
 

--- a/test/test_dynamic_line_rating.py
+++ b/test/test_dynamic_line_rating.py
@@ -26,8 +26,8 @@ def test_ieee_sample_case():
         "height": 0,
         "wnd_azimuth": 0,
         "influx_direct": 1027,
-        "solar_position: altitude": np.pi / 2,
-        "solar_position: azimuth": np.pi,
+        "solar_altitude": np.pi / 2,
+        "solar_azimuth": np.pi,
     }
 
     psi = 90  # line azimuth
@@ -60,8 +60,8 @@ def test_oeding_and_oswald_sample_case():
         "height": 0,
         "wnd_azimuth": 0,
         "influx_direct": 0,
-        "solar_position: altitude": np.pi / 2,
-        "solar_position: azimuth": np.pi,
+        "solar_altitude": np.pi / 2,
+        "solar_azimuth": np.pi,
     }
     psi = 90  # line azimuth
     D = 0.0218  # line diameter
@@ -89,8 +89,8 @@ def test_suedkabel_sample_case():
         "height": 0,
         "wnd_azimuth": 0,
         "influx_direct": 0,
-        "solar_position: altitude": np.pi / 2,
-        "solar_position: azimuth": np.pi,
+        "solar_altitude": np.pi / 2,
+        "solar_azimuth": np.pi,
     }
     R = 0.0136 * 1e-3
     psi = 0  # line azimuth
@@ -113,8 +113,8 @@ def test_right_angle_in_different_configuration():
         "height": 0,
         "wnd_azimuth": 0,
         "influx_direct": 1027,
-        "solar_position: altitude": np.pi / 2,
-        "solar_position: azimuth": np.pi,
+        "solar_altitude": np.pi / 2,
+        "solar_azimuth": np.pi,
     }
     psi = 90  # line azimuth
     D = 0.02814  # line diameter
@@ -159,8 +159,8 @@ def test_angle_increase():
         "height": 0,
         "wnd_azimuth": 0,
         "influx_direct": 1027,
-        "solar_position: altitude": np.pi / 2,
-        "solar_position: azimuth": np.pi,
+        "solar_altitude": np.pi / 2,
+        "solar_azimuth": np.pi,
     }
     D = 0.02814  # line diameter
     Ts = 273 + 100  # max allowed line surface temp


### PR DESCRIPTION
Closes #212 
Touches #211 

## Change proposed in this Pull Request

Initial attempt was to solve #211, but is turns out to be tricky. The problem is that the era5 module relies on get_<feature> functions which take the era5 retrieval parameters as an argument. The SolarPosition function however requires a dataset with the complete set of coordinates. It would be necessary to pass the `cutout.data` as an argument to the `get_solar_position` function. This requires changes one have to think through a bit. 
The same counts for the sarah module. Its `get_data` function does not use the `feature` argument so far. It would be necessary to make separate `get_influx` and `get_solar_position` functions. I would postpone that change to another time. 

In order to make the `influx` feature still a bit handier, I removed the solar athmospheric insolation variable from the `influx` feature as well as from the `SolarPosition` function. The variables were renamed to `solar_azimuth` and `solar_altitude`. 

## Motivation and Context

Make the `influx` feature leaner. Make data variables accessible via `cutout.data.solar_altitude`/ `cutout.data.solar_azimuth`

## How Has This Been Tested?

No test added.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
