### PR TITLE
Fix bad comparison for sarah datafiles.

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,10 @@ Release Notes
 .. Upcoming Release
 .. =================
 
+* Bugfix: When creating cutouts using SARAH2 data, an error was previously wrongly thrown if exactly
+  the data was available as input as required. The error is now correctly thrown only if
+  insufficient SARAH data is available.
+
 Version 0.2.7 
 ==============
 

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -63,7 +63,7 @@ def get_filenames(sarah_dir, coords):
         files = pd.Series(glob.glob(pattern, recursive=True))
         assert not files.empty, (
             f"No files found at {pattern}. Make sure "
-            "sarah_dir points to the correct directory!"
+            f"sarah_dir points to the correct directory!"
         )
 
         files.index = pd.to_datetime(files.str.extract(r"SI.in(\d{8})", expand=False))
@@ -75,13 +75,14 @@ def get_filenames(sarah_dir, coords):
         axis=1,
     )
 
-    start = coords["time"].to_index()[0]
-    end = coords["time"].to_index()[-1]
+    # SARAH files are named based on day, need to .floor("D") to compare correctly
+    start = coords["time"].to_index()[0].floor("D")
+    end = coords["time"].to_index()[-1].floor("D")
 
     if (start < files.index[0]) or (end > files.index[-1]):
         logger.error(
             f"Files in {sarah_dir} do not cover the whole time span:"
-            f"\n\t{start} until {end}"
+            f"\t{start} until {end}"
         )
 
     return files.loc[(files.index >= start) & (files.index <= end)].sort_index()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Change proposed in this Pull Request

Fix a bad comparison when creating cutouts with SARAH2 data.
Previously if the cutout was to be created for e.g. an upper end of "2013-12-31 23:00" and the `sarah_dir` did only contain datafiles for 2013 (i.e. labelled "xxx20131223yyy.nc"), then the comparison failed and the error was thrown.

This bug was not discovered because we had previously always downloaded multiple SARAH2 dataset years, i.e. more than 2013 were contained in the same directory and the bug did not surface.

Fixing this here.


## How Has This Been Tested?
Locally. New cutout with SARAH data created.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
