### PR TITLE
Fix rasterio reprojection bug. Appears with 1.2.10

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,6 +18,9 @@ Release Notes
   not opened and an error was thrown. The error did not occur if one or more shapes were included.
   Error is corrected and geometry-only exclusions can now be calculated. (GH Issue #225)
 * Atlite now includes the reference turbines from the NREL turbine archive (see: https://nrel.github.io/turbine-models/). Available turbines can be consulted using `atlite.windturbines` and can be passed as string argument, e.g. `coutout.wind(turbine)`.
+* Bugfix: Downsampling the availability matrix (high resolution to low resolution) failed. Only rasters with 0 or 1
+  were produced. Expected are also floats between 0 and 1 (GH Issue #238). Changing the rasterio version solved this.
+  See solution (https://github.com/PyPSA/atlite/pull/240).
 
 Version 0.2.7 
 ==============

--- a/environment.yaml
+++ b/environment.yaml
@@ -22,7 +22,7 @@ dependencies:
 - geopandas
 - cdsapi
 - pyproj>=2.0
-- rasterio>=1.0
+- rasterio>=1.0,<1.2.10  # until 1.3.0 is released
 - shapely
 - progressbar2
 - tqdm


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #238 .

The problem and solution are described in issue https://github.com/PyPSA/atlite/issues/238

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I run **pytest** before and after the changes. See more about my reproducable testing procedure here -> https://github.com/PyPSA/atlite/issues/238

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up. (no more than previously existing -> there is one error irrespective of the reprojection stuff) 
- [x] I have adjusted the docstrings in the code appropriately.
- [NA] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
