### PR TITLE
Fix NaN values into inflow

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -21,6 +21,7 @@ Release Notes
 * Bugfix: Downsampling the availability matrix (high resolution to low resolution) failed. Only rasters with 0 or 1
   were produced. Expected are also floats between 0 and 1 (GH Issue #238). Changing the rasterio version solved this.
   See solution (https://github.com/PyPSA/atlite/pull/240).
+* Bugfix: Avoid NaN values into the hydro inflows
 
 Version 0.2.7 
 ==============

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -103,6 +103,6 @@ def shift_and_aggregate_runoff_for_plants(
         nhours = (distances * (flowspeed * 3.6) + 0.5).astype(int)
 
         for b in ppl.upstream:
-            upstream_inflow_b = runoff.sel(hid=b).shift(time=nhours.at[b], fill_value=0)
+            inflow_plant += runoff.sel(hid=b).roll(time=nhours.at[b])
 
     return inflow

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -103,6 +103,11 @@ def shift_and_aggregate_runoff_for_plants(
         nhours = (distances * (flowspeed * 3.6) + 0.5).astype(int)
 
         for b in ppl.upstream:
-            inflow_plant += runoff.sel(hid=b).shift(time=nhours.at[b])
+            # get upstream inflows
+            upstream_inflow_b = runoff.sel(hid=b).shift(time=nhours.at[b])
+            # replace null values with zeros
+            upstream_inflow_b.where(upstream_inflow_b.isnull()==False, 0.0)
+            # update inflow for the plant
+            inflow_plant += upstream_inflow_b
 
     return inflow

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -106,7 +106,7 @@ def shift_and_aggregate_runoff_for_plants(
             # get upstream inflows
             upstream_inflow_b = runoff.sel(hid=b).shift(time=nhours.at[b])
             # replace null values with zeros
-            upstream_inflow_b.where(upstream_inflow_b.isnull()==False, 0.0)
+            upstream_inflow_b = upstream_inflow_b.where(upstream_inflow_b.isnull()==False, 0.0)
             # update inflow for the plant
             inflow_plant += upstream_inflow_b
 

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -106,7 +106,9 @@ def shift_and_aggregate_runoff_for_plants(
             # get upstream inflows
             upstream_inflow_b = runoff.sel(hid=b).shift(time=nhours.at[b])
             # replace null values with zeros
-            upstream_inflow_b = upstream_inflow_b.where(upstream_inflow_b.isnull()==False, 0.0)
+            upstream_inflow_b = upstream_inflow_b.where(
+                upstream_inflow_b.isnull() == False, 0.0
+            )
             # update inflow for the plant
             inflow_plant += upstream_inflow_b
 

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -103,13 +103,6 @@ def shift_and_aggregate_runoff_for_plants(
         nhours = (distances * (flowspeed * 3.6) + 0.5).astype(int)
 
         for b in ppl.upstream:
-            # get upstream inflows
-            upstream_inflow_b = runoff.sel(hid=b).shift(time=nhours.at[b])
-            # replace null values with zeros
-            upstream_inflow_b = upstream_inflow_b.where(
-                upstream_inflow_b.isnull() == False, 0.0
-            )
-            # update inflow for the plant
-            inflow_plant += upstream_inflow_b
+            upstream_inflow_b = runoff.sel(hid=b).shift(time=nhours.at[b], fill_value=0)
 
     return inflow


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #241 

## Change proposed in this Pull Request

This PR aims at avoiding NaN values into the inflow.
Any NaN value would be converted into 0.0 instead before summing to the inflow.

## Description
<!--- Describe your changes in detail -->
When performing the shift of the inflow dataarray, some NaN values appears hence leading to NaN values into the sum.
This has been fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If NaN values remain, this may lead to issues in the usage of the tool

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using pypsa-africa

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
