### PR TITLE
Improve memory load efficiency for shape_availability calculation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -21,6 +21,9 @@ Release Notes
 * Bugfix: Downsampling the availability matrix (high resolution to low resolution) failed. Only rasters with 0 or 1
   were produced. Expected are also floats between 0 and 1 (GH Issue #238). Changing the rasterio version solved this.
   See solution (https://github.com/PyPSA/atlite/pull/240).
+* Breaking Change: Due to better performance and memory efficiency the method of matrix summation, as well as the matrix dtpyes within `shape_availability()` in `atlite.gis`, have been changed.
+  The returned object `masked` (numpy.array) is now dtype `bool` instead of `float64`. This can create broken workflows, if `masked` is not transformed ahead of certain operations. 
+  A warning message has been added. (https://github.com/PyPSA/atlite/pull/243) 
 
 Version 0.2.7 
 ==============

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -22,8 +22,7 @@ Release Notes
   were produced. Expected are also floats between 0 and 1 (GH Issue #238). Changing the rasterio version solved this.
   See solution (https://github.com/PyPSA/atlite/pull/240).
 * Breaking Change: Due to better performance and memory efficiency the method of matrix summation, as well as the matrix dtpyes within `shape_availability()` in `atlite.gis`, have been changed.
-  The returned object `masked` (numpy.array) is now dtype `bool` instead of `float64`. This can create broken workflows, if `masked` is not transformed ahead of certain operations. 
-  A warning message has been added. (https://github.com/PyPSA/atlite/pull/243) 
+  The returned object `masked` (numpy.array) is now dtype `bool` instead of `float64`. This can create broken workflows, if `masked` is not transformed ahead of certain operations (https://github.com/PyPSA/atlite/pull/243).
 * Bugfix: Avoid NaN values into the hydro inflows
 
 Version 0.2.7 

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -461,11 +461,11 @@ def shape_availability(geometry, excluder):
             iterations = int(d["buffer"] / excluder.res) + 1
             masked_ = dilation(masked_, iterations=iterations)
 
-        exclusions = sum([exclusions, masked_])
+        exclusions = exclusions | masked_
 
     for idx, d in enumerate(excluder.geometries, start=1):
         masked = ~geometry_mask(d["geometry"], shape, transform, invert=d["invert"])
-        exclusions = sum([exclusions, masked])
+        exclusions = exclusions | masked
 
     return (exclusions == False), transform
 

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -467,7 +467,7 @@ def shape_availability(geometry, excluder):
         masked = ~geometry_mask(d["geometry"], shape, transform, invert=d["invert"])
         exclusions = exclusions | masked
 
-    return (exclusions == False), transform
+    return ~exclusions, transform
 
 
 def shape_availability_reprojected(

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -426,7 +426,6 @@ def shape_availability(geometry, excluder):
         Affine transform of the mask.
 
     """
-    exclusions = []
     if not excluder.all_open:
         excluder.open_files()
     assert geometry.crs == excluder.crs

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -448,14 +448,14 @@ def shape_availability(geometry, excluder):
             )
         if d["codes"]:
             if callable(d["codes"]):
-                masked_ = d["codes"](masked)
+                masked_ = d["codes"](masked).astype(bool)
             else:
                 masked_ = isin(masked, d["codes"])
         else:
-            masked_ = masked
+            masked_ = masked.astype(bool)
 
         if d["invert"]:
-            masked_ = ~(masked_).astype(bool)
+            masked_ = ~masked_
         if d["buffer"]:
             iterations = int(d["buffer"] / excluder.res) + 1
             masked_ = dilation(masked_, iterations=iterations)
@@ -508,7 +508,7 @@ def shape_availability_reprojected(
         masked, transform, dst_transform, excluder.crs, dst_crs
     )
     return rio.warp.reproject(
-        masked,
+        masked.astype(np.uint8),
         empty(dst_shape),
         resampling=rio.warp.Resampling.average,
         src_transform=transform,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Changes proposed in this Pull Request
Improving the efficiency of `shape_availibility()` with respect to memory load through changes in dtypes and the method of mask summation.  

<!--- Provide a general, short summary of your changes in the title above -->

## Description
Two main changes are made to reduce the memory load while running `shape_availability()` within gis.py:

-  dtype transformations via `np.astype()` to `int32` are removed on several occasions to keep matrices returned from functions as `rasterio.features.geometry_mask()` and `scipy.ndimage.morphology.binary_dialation()`  in dtype `bool`. 
The dtype transformation to `float64`, applied to the final mask that is returned by the function, is removed.
-  Instead of saving individual masks for every exclusion raster or geometry to a list and summing them on the return, a new method is introduced, which adds the masks on every loop iteration. This is done via the `|` OR operator, to keep the single mask in memory as dtype `bool`.

<!--- Describe your changes in detail -->

## Motivation and Context
With higher resolution rasters or greater land area covered, the underlying matrices, when calculating the eligible area via ` shape_availability()`, quickly grow in size. E.g., a raster with 50 meter resolution bound by the shape of Germany produces an array of shape (17086, 12679). With the current method of storing an individual mask for every raster added to the `ExclusionContainer()` in dtype `int32` this can lead to infeasible memory usage for conventional systems. The changes enhance the efficiency of storing information, as well the method of combining information form multiple rasters. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
So far tested locally with the latest version of atlite. Tests included rasters with buffers, inverted rasters as well as geometries. 
`pytest` did not bring up unexpected errors. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
