### PR TITLE
gis: extend allowed time frame to 1959

### DIFF
--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -70,7 +70,7 @@ def get_coords(x, y, time, dx=0.25, dy=0.25, dt="h", **kwargs):
         {
             "x": np.round(np.arange(-180, 180, dx), 9),
             "y": np.round(np.arange(-90, 90, dy), 9),
-            "time": pd.date_range(start="1979", end="now", freq=dt),
+            "time": pd.date_range(start="1959", end="now", freq=dt),
         }
     )
     ds = ds.assign_coords(lon=ds.coords["x"], lat=ds.coords["y"])


### PR DESCRIPTION
ERA5 stable reanalysis product has been extended to data from 1959 onwards (https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels).