### PR TITLE
Issue227 - Turbine, Panel and CSP Installation Configs from local path

### DIFF
--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -53,10 +53,17 @@ def get_windturbineconfig(turbine):
         return get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
     if isinstance(turbine, str):
-        if not turbine.endswith(".yaml"):
-            turbine += ".yaml"
+        
+        if not Path(turbine).exists():
 
-        turbine = WINDTURBINE_DIRECTORY / turbine
+            if not turbine.endswith(".yaml"):
+                turbine += ".yaml"
+
+            turbine = WINDTURBINE_DIRECTORY / turbine
+        
+        else:
+
+            turbine = Path(turbine)
 
     with open(turbine, "r") as f:
         conf = yaml.safe_load(f)

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -106,19 +106,16 @@ def get_cspinstallationconfig(installation):
     config : dict
         Config with details on the CSP installation.
     """
-
         
     if not Path(installation).exists():        
 
         # if isinstance(installation, str):    # not sure what this does
         if not installation.endswith(".yaml"):
             installation += ".yaml"
-
         installation = CSPINSTALLATION_DIRECTORY / installation
     
     else:
         installation = Path(installation)
-    
 
     # Load and set expected index columns
     with open(installation, "r") as f:

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -42,24 +42,24 @@ def get_windturbineconfig(turbine):
 
     Parameters
     ----------
-    turbine : str
+    turbine : str or pathlib.Path
         Name of the local turbine file.
-        Alternatively a dict for selecting a turbine from the Open Energy
+        Alternatively, a dict for selecting a turbine from the Open Energy
         Database, in this case the key 'source' should be contained. For all
         other key arguments to retrieve the matching turbine, see
         atlite.resource.download_windturbineconfig() for details.
     """
 
+    assert isinstance(turbine, (str, Path))
+
     if isinstance(turbine, str) and turbine.startswith("oedb:"):
         return get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
     if isinstance(turbine, str):
-
-        if not Path(turbine).exists():
-            if not turbine.endswith(".yaml"):
-                turbine += ".yaml"
-
-            turbine = WINDTURBINE_DIRECTORY / turbine
+        try:
+            turbine = windturbines[turbine.replace(".yaml", "").replace(".yml", "")]
+        except KeyError:
+            pass
 
     with open(turbine, "r") as f:
         conf = yaml.safe_load(f)
@@ -75,15 +75,13 @@ def get_windturbineconfig(turbine):
 def get_solarpanelconfig(panel):
     """Load the 'panel'.yaml file from local disk and provide a solar panel dict."""
 
+    assert isinstance(panel, (str, Path))
+
     if isinstance(panel, str):
-
-        if not Path(panel).exists():
-            if not panel.endswith(".yaml"):
-                panel += ".yaml"
-            panel = SOLARPANEL_DIRECTORY / panel
-
-        else:
-            panel = Path(panel)
+        try:
+            panel = solarpanels[panel.replace(".yaml", "").replace(".yml", "")]
+        except KeyError:
+            pass
 
     with open(panel, "r") as f:
         conf = yaml.safe_load(f)
@@ -96,7 +94,7 @@ def get_cspinstallationconfig(installation):
 
     Parameters
     ----------
-    installation : str
+    installation : str or pathlib.Path
         Name of CSP installation kind. Can either correspond to name of one of the files
         in resources/cspinstallation or be a local file.
 
@@ -106,15 +104,16 @@ def get_cspinstallationconfig(installation):
         Config with details on the CSP installation.
     """
 
-    if not Path(installation).exists():
+    assert isinstance(installation, (str, Path))
 
-        # if isinstance(installation, str):    # not sure what this does
-        if not installation.endswith(".yaml"):
-            installation += ".yaml"
-        installation = CSPINSTALLATION_DIRECTORY / installation
-
-    else:
-        installation = Path(installation)
+    if isinstance(installation, str):
+        try:
+            installation = cspinstallations[
+                installation.replace(".yml", "").replace(".yaml", "")
+            ]
+            installation = CSPINSTALLATION_DIRECTORY / installation
+        except KeyError:
+            pass
 
     # Load and set expected index columns
     with open(installation, "r") as f:

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -59,9 +59,8 @@ def get_windturbineconfig(turbine):
                 turbine += ".yaml"
 
             turbine = WINDTURBINE_DIRECTORY / turbine
+
         
-        else:
-            turbine = Path(turbine)
 
     with open(turbine, "r") as f:
         conf = yaml.safe_load(f)
@@ -78,10 +77,14 @@ def get_solarpanelconfig(panel):
     """Load the 'panel'.yaml file from local disk and provide a solar panel dict."""
 
     if isinstance(panel, str):
-        if not panel.endswith(".yaml"):
-            panel += ".yaml"
+        
+        if not Path(panel).exists():
+            if not panel.endswith(".yaml"):
+                panel += ".yaml"
+            panel = SOLARPANEL_DIRECTORY / panel
 
-        panel = SOLARPANEL_DIRECTORY / panel
+        else:
+            panel = Path(panel)
 
     with open(panel, "r") as f:
         conf = yaml.safe_load(f)
@@ -104,11 +107,18 @@ def get_cspinstallationconfig(installation):
         Config with details on the CSP installation.
     """
 
-    if isinstance(installation, str):
+        
+    if not Path(installation).exists():        
+
+        # if isinstance(installation, str):    # not sure what this does
         if not installation.endswith(".yaml"):
             installation += ".yaml"
 
-    installation = CSPINSTALLATION_DIRECTORY / installation
+        installation = CSPINSTALLATION_DIRECTORY / installation
+    
+    else:
+        installation = Path(installation)
+    
 
     # Load and set expected index columns
     with open(installation, "r") as f:

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -55,14 +55,12 @@ def get_windturbineconfig(turbine):
     if isinstance(turbine, str):
         
         if not Path(turbine).exists():
-
             if not turbine.endswith(".yaml"):
                 turbine += ".yaml"
 
             turbine = WINDTURBINE_DIRECTORY / turbine
         
         else:
-
             turbine = Path(turbine)
 
     with open(turbine, "r") as f:

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -56,12 +56,12 @@ def get_windturbineconfig(turbine):
         return get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
     if isinstance(turbine, str):
-        try:
-            turbine = windturbines[turbine.replace(".yaml", "").replace(".yml", "")]
-        except KeyError:
-            pass
+        turbine_path = windturbines[turbine.replace(".yaml", "")]
 
-    with open(turbine, "r") as f:
+    if isinstance(turbine, Path):
+        turbine_path = turbine
+
+    with open(turbine_path, "r") as f:
         conf = yaml.safe_load(f)
 
     return dict(
@@ -78,12 +78,13 @@ def get_solarpanelconfig(panel):
     assert isinstance(panel, (str, Path))
 
     if isinstance(panel, str):
-        try:
-            panel = solarpanels[panel.replace(".yaml", "").replace(".yml", "")]
-        except KeyError:
-            pass
+        panel = panel.replace(".yaml", "")
+        panel_path = solarpanels[panel]
 
-    with open(panel, "r") as f:
+    elif isinstance(panel, Path):
+        panel_path = panel
+
+    with open(panel_path, "r") as f:
         conf = yaml.safe_load(f)
 
     return conf
@@ -107,19 +108,17 @@ def get_cspinstallationconfig(installation):
     assert isinstance(installation, (str, Path))
 
     if isinstance(installation, str):
-        try:
-            installation = cspinstallations[
-                installation.replace(".yml", "").replace(".yaml", "")
-            ]
-            installation = CSPINSTALLATION_DIRECTORY / installation
-        except KeyError:
-            pass
+        installation_path = cspinstallations[installation]
+
+    if isinstance(installation, Path):
+        installation_path = installation
 
     # Load and set expected index columns
-    with open(installation, "r") as f:
+    with open(installation_path, "r") as f:
         config = yaml.safe_load(f)
+    config["path"] = installation_path
 
-    config["path"] = installation
+    print(config)
 
     ## Convert efficiency dict to xr.DataArray and convert units to deg -> rad, % -> p.u.
     da = pd.DataFrame(config["efficiency"]).set_index(["altitude", "azimuth"])

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -38,9 +38,13 @@ def get_windturbineconfig(turbine):
     ----------
     turbine : str or pathlib.Path
         if str:
-            either from Open Energy Database (key "source" should then be contained)
-            or the name of a preshipped turbine from atlite.resources.windturbines
-        if Path: a local file is expected
+            The name of a preshipped turbine from alite.resources.windturbine .
+            Alternatively, if a str starting with 'oedb:<name>' is passed the Open
+            Energy Database is searched for a turbine with the matching '<name>'
+            and if found that turbine configuration is used. See
+            `atlite.resource.get_oedb_windturbineconfig(...)`
+        if `pathlib.Path` is provided the configuration is read from this local
+            path instead
 
     Returns
     ----------
@@ -53,10 +57,10 @@ def get_windturbineconfig(turbine):
     if isinstance(turbine, str) and turbine.startswith("oedb:"):
         return get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
-    if isinstance(turbine, str):
+    elif isinstance(turbine, str):
         turbine_path = windturbines[turbine.replace(".yaml", "")]
 
-    if isinstance(turbine, Path):
+    elif isinstance(turbine, Path):
         turbine_path = turbine
 
     with open(turbine_path, "r") as f:
@@ -76,9 +80,10 @@ def get_solarpanelconfig(panel):
     Parameters
     ----------
     panel : str or pathlib.Path
-        if str: expects name to match one of the preshipped panels from
-            atlite.resources.solarpanel
-        if Path: a local file is expected
+        if str is provided the name of a preshipped panel
+            from alite.resources.solarpanel is expected.
+        if `pathlib.Path` is provided the configuration
+            is read from this local path instead
 
     Returns
     ----------
@@ -89,8 +94,7 @@ def get_solarpanelconfig(panel):
     assert isinstance(panel, (str, Path))
 
     if isinstance(panel, str):
-        panel = panel.replace(".yaml", "")
-        panel_path = solarpanels[panel]
+        panel_path = solarpanels[panel.replace(".yaml", "")]
 
     elif isinstance(panel, Path):
         panel_path = panel
@@ -107,9 +111,10 @@ def get_cspinstallationconfig(installation):
     Parameters
     ----------
     installation : str or pathlib.Path
-        if str: expects name to match one of the preshipped installations from
-            atlite.resources.cspinstallation
-        if Path: a local file is expected
+        if str is provided the name of a preshipped CSP installation
+            from alite.resources.cspinstallation is expected.
+        if `pathlib.Path` is provided the configuration
+            is read from this local path instead
 
     Returns
     -------
@@ -120,9 +125,9 @@ def get_cspinstallationconfig(installation):
     assert isinstance(installation, (str, Path))
 
     if isinstance(installation, str):
-        installation_path = cspinstallations[installation]
+        installation_path = cspinstallations[installation.replace(".yaml", "")]
 
-    if isinstance(installation, Path):
+    elif isinstance(installation, Path):
         installation_path = installation
 
     # Load and set expected index columns

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -54,14 +54,12 @@ def get_windturbineconfig(turbine):
         return get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
     if isinstance(turbine, str):
-        
+
         if not Path(turbine).exists():
             if not turbine.endswith(".yaml"):
                 turbine += ".yaml"
 
             turbine = WINDTURBINE_DIRECTORY / turbine
-
-        
 
     with open(turbine, "r") as f:
         conf = yaml.safe_load(f)
@@ -78,7 +76,7 @@ def get_solarpanelconfig(panel):
     """Load the 'panel'.yaml file from local disk and provide a solar panel dict."""
 
     if isinstance(panel, str):
-        
+
         if not Path(panel).exists():
             if not panel.endswith(".yaml"):
                 panel += ".yaml"
@@ -107,21 +105,14 @@ def get_cspinstallationconfig(installation):
     config : dict
         Config with details on the CSP installation.
     """
-        
-    if not Path(installation).exists(
 
-
-
-
-
-
-    ):
+    if not Path(installation).exists():
 
         # if isinstance(installation, str):    # not sure what this does
         if not installation.endswith(".yaml"):
             installation += ".yaml"
         installation = CSPINSTALLATION_DIRECTORY / installation
-    
+
     else:
         installation = Path(installation)
 

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -108,7 +108,14 @@ def get_cspinstallationconfig(installation):
         Config with details on the CSP installation.
     """
         
-    if not Path(installation).exists():        
+    if not Path(installation).exists(
+
+
+
+
+
+
+    ):
 
         # if isinstance(installation, str):    # not sure what this does
         if not installation.endswith(".yaml"):

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -118,8 +118,6 @@ def get_cspinstallationconfig(installation):
         config = yaml.safe_load(f)
     config["path"] = installation_path
 
-    print(config)
-
     ## Convert efficiency dict to xr.DataArray and convert units to deg -> rad, % -> p.u.
     da = pd.DataFrame(config["efficiency"]).set_index(["altitude", "azimuth"])
 

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -34,10 +34,11 @@ CSPINSTALLATION_DIRECTORY = RESOURCE_DIRECTORY / "cspinstallation"
 def get_windturbineconfig(turbine):
     """Load the wind 'turbine' configuration.
 
-    The configuration can either be one from local storage, then 'turbine' is
+    The configuration can be one from local storage, then 'turbine' is
     considered part of the file base name '<turbine>.yaml' in config.windturbine_dir.
-    Alternatively the configuration can be downloaded from the Open Energy Database (OEDB),
+    Alternatively, the configuration can be downloaded from the Open Energy Database (OEDB),
     in which case 'turbine' is a dictionary used for selecting a turbine from the database.
+    Finally, turbine can also be a path to a local config file.
 
     Parameters
     ----------
@@ -98,8 +99,8 @@ def get_cspinstallationconfig(installation):
     Parameters
     ----------
     installation : str
-        Name of CSP installation kind. Must correspond to name of one of the files
-        in resources/cspinstallation.
+        Name of CSP installation kind. Can either correspond to name of one of the files
+        in resources/cspinstallation or be a local file.
 
     Returns
     -------

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -34,20 +34,18 @@ CSPINSTALLATION_DIRECTORY = RESOURCE_DIRECTORY / "cspinstallation"
 def get_windturbineconfig(turbine):
     """Load the wind 'turbine' configuration.
 
-    The configuration can be one from local storage, then 'turbine' is
-    considered part of the file base name '<turbine>.yaml' in config.windturbine_dir.
-    Alternatively, the configuration can be downloaded from the Open Energy Database (OEDB),
-    in which case 'turbine' is a dictionary used for selecting a turbine from the database.
-    Finally, turbine can also be a path to a local config file.
-
     Parameters
     ----------
     turbine : str or pathlib.Path
-        Name of the local turbine file.
-        Alternatively, a dict for selecting a turbine from the Open Energy
-        Database, in this case the key 'source' should be contained. For all
-        other key arguments to retrieve the matching turbine, see
-        atlite.resource.download_windturbineconfig() for details.
+        if str:
+            either from Open Energy Database (key "source" should then be contained)
+            or the name of a preshipped turbine from atlite.resources.windturbines
+        if Path: a local file is expected
+
+    Returns
+    ----------
+    config : dict
+        Config with details on the turbine
     """
 
     assert isinstance(turbine, (str, Path))
@@ -73,7 +71,20 @@ def get_windturbineconfig(turbine):
 
 
 def get_solarpanelconfig(panel):
-    """Load the 'panel'.yaml file from local disk and provide a solar panel dict."""
+    """Load the 'panel'.yaml file from local disk and provide a solar panel dict.
+
+    Parameters
+    ----------
+    panel : str or pathlib.Path
+        if str: expects name to match one of the preshipped panels from
+            atlite.resources.solarpanel
+        if Path: a local file is expected
+
+    Returns
+    ----------
+    config : dict
+        Config with details on the solarpanel
+    """
 
     assert isinstance(panel, (str, Path))
 
@@ -96,8 +107,9 @@ def get_cspinstallationconfig(installation):
     Parameters
     ----------
     installation : str or pathlib.Path
-        Name of CSP installation kind. Can either correspond to name of one of the files
-        in resources/cspinstallation or be a local file.
+        if str: expects name to match one of the preshipped installations from
+            atlite.resources.cspinstallation
+        if Path: a local file is expected
 
     Returns
     -------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,3 +4,7 @@
   SPDX-License-Identifier: CC-BY-4.0
 
 .. include:: ../RELEASE_NOTES.rst
+
+* In atlite/resource.py, the functions ``get_windturbineconfig``, ``get_solarpanelconfig``, and 
+  ``get_cspinstallationconfig`` will now recognize if a local file was passed, and load
+  it instead of one of the predefined ones.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,6 +5,6 @@
 
 .. include:: ../RELEASE_NOTES.rst
 
-* In atlite/resource.py, the functions ``get_windturbineconfig``, ``get_solarpanelconfig``, and 
-  ``get_cspinstallationconfig`` will now recognize if a local file was passed, and load
+* In ``atlite/resource.py``, the functions ``get_windturbineconfig``, ``get_solarpanelconfig``, and 
+  ``get_cspinstallationconfig`` will now recognize if a local file was passed, and if so load
   it instead of one of the predefined ones.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #227.

## Change proposed in this Pull Request

<!--- Provide a general, short summary of your changes in the title above -->
Methods ``get_windturbineconfig``, ``get_solarpanelconfig`` and ``get_cspinstallationconfig`` load yaml files based on the passed
configuration name. Now, additionally, the methods recognize if a path to a locally stored config is passed.
The file is then loaded instead of a predefined config.


## Description
<!--- Describe your changes in detail -->
The methods run ``Path([the local path]).exists()`` to check if the path exists. If not, the methods assume that the user passed 
the name of a config, and proceeds as before the change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a small change, proposed a while ago by @fneum. I seems like a sensible addition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I checked all three functions to make sure that both old and new behaviour are behaving as expected.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up. (one apparently unrelated error)
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
