### PR TITLE
hydro inflow unit conversion corrected

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -17,6 +17,7 @@ Upcoming Release
 * Bugfix: For certain time spans, the ERA5 influx data would be incorrectly shifted by 12 hours.
   This is now fixed and influx data is **always** shifted by minus 30 minutes.
   See `#256 <https://github.com/PyPSA/atlite/issues/256#issuecomment-1271446531>`_ for details.
+* Bugfix: The hydro inflow calculation was relying on a wrong distance calculation in `atlite.hydro.shift_and_aggregate_runoff_for_plants`. This is now fixed. 
 
 Version 0.2.9
 =============

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -100,7 +100,7 @@ def shift_and_aggregate_runoff_for_plants(
             basins.meta.loc[ppl.upstream, "DIST_MAIN"]
             - basins.meta.at[ppl.hid, "DIST_MAIN"]
         )
-        nhours = (distances * (flowspeed * 3.6) + 0.5).astype(int)
+        nhours = (distances / (flowspeed * 3.6) + 0.5).astype(int)
 
         for b in ppl.upstream:
             inflow_plant += runoff.sel(hid=b).roll(time=nhours.at[b])


### PR DESCRIPTION
In hydro.py, line 103
`nhours = (distances * (flowspeed * 3.6) + 0.5).astype(int)`
should be
`nhours = ((distances * 1000) / (flowspeed * 3600) + 0.5).astype(int)`
or
`nhours = (distances / (flowspeed * 3.6) + 0.5).astype(int)`