### PR TITLE
Always shift solar influx by 30 minutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ atlite/version.py
 paper
 .coverage*
 !.coveragerc
+
+# Ignore PyCharm / JetBrains IDE project files
+.idea/

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,13 @@ Release Notes
 .. Upcoming Release
 .. =================
 
+Upcoming Release
+================
+
+* Bugfix: For certain time spans, the ERA5 influx data would be incorrectly shifted by 12 hours.
+  This is now fixed and influx data is **always** shifted by minus 30 minutes.
+  See `#256 <https://github.com/PyPSA/atlite/issues/256#issuecomment-1271446531>`_ for details.
+
 Version 0.2.9
 =============
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -160,17 +160,7 @@ def get_data_influx(retrieval_params):
     # Do not show DeprecationWarning from new SolarPosition calculation (#199)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        # Convert dt / time frequency to timedelta and shift solar position by half
-        # (freqs like ["H","30T"] do not work with pd.to_timedelta(...)
-        time_shift = (
-            -1
-            / 2
-            * pd.to_timedelta(
-                pd.date_range(
-                    "1970-01-01", periods=1, freq=pd.infer_freq(ds["time"])
-                ).freq
-            )
-        )
+        time_shift = pd.to_timedelta("-30 minutes")
         sp = SolarPosition(ds, time_shift=time_shift)
     sp = sp.rename({v: f"solar_{v}" for v in sp.data_vars})
 

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -307,6 +307,24 @@ def cutout_era5(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
+def cutout_era5_3h_sampling(tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp("era5")
+    time = [
+        f"{TIME} 00:00",
+        f"{TIME} 03:00",
+        f"{TIME} 06:00",
+        f"{TIME} 09:00",
+        f"{TIME} 12:00",
+        f"{TIME} 15:00",
+        f"{TIME} 18:00",
+        f"{TIME} 21:00",
+    ]
+    cutout = Cutout(path=tmp_path / "era5", module="era5", bounds=BOUNDS, time=time)
+    cutout.prepare()
+    return cutout
+
+
+@pytest.fixture(scope="session")
 def cutout_era5_2days_crossing_months(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("era5")
     time = slice("2013-02-28", "2013-03-01")
@@ -502,6 +520,11 @@ class TestERA5:
     def test_pv_era5_2days_crossing_months(cutout_era5_2days_crossing_months):
         """See https://github.com/PyPSA/atlite/issues/256"""
         return pv_test(cutout_era5_2days_crossing_months, time="2013-03-01")
+
+    @staticmethod
+    def test_pv_era5_3h_sampling(cutout_era5_3h_sampling):
+        assert pd.infer_freq(cutout_era5_3h_sampling.data.time) == "3H"
+        return pv_test(cutout_era5_3h_sampling)
 
     @staticmethod
     def test_wind_era5(cutout_era5):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Always Shift Solar Influx by 30 Minutes

<!--- Provide a general, short summary of your changes in the title above -->

## Description
Fixes a bug in solar position time shift for ERA5 influx data where for some cases the frequency of the data would be incorrectly inferred. The change always shifts by -30 minutes, regardless of the sampling of the data. See discussion in https://github.com/PyPSA/atlite/issues/256#issuecomment-1268473262 for reasoning.
<!--- Describe your changes in detail -->

## Motivation and Context
Closes #256

## How Has This Been Tested?
* The [first commit](c190c3410b037e278a632322dff400311e925bb8) in the pull request introduces a [failing unit test](https://github.com/zoltanmaric/atlite/blob/90c593142371d9a2a9c97e5a13d5d128594a84cc/test/test_preparation_and_conversion.py#L501-L504) that demonstrates the bug reported in #256.
* The [second commit](90c593142371d9a2a9c97e5a13d5d128594a84cc) fixes the bug by always shifting by 30 minutes (removing the inference of the frequency of the data)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
