### PR TITLE
Combine ERA5 and ERA5T data

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,6 +19,9 @@ Upcoming Release
   See `#256 <https://github.com/PyPSA/atlite/issues/256#issuecomment-1271446531>`_ for details.
 * Bugfix: The hydro inflow calculation was relying on a wrong distance calculation in `atlite.hydro.shift_and_aggregate_runoff_for_plants`. This is now fixed.
 * Add a reference to the PyPSA ecosystem community server hosted on `Discord <https://discord.gg/AnuJBk23FU>`_
+* Bugfix: building cutouts spanning the most recent few months resulted in errors due to the
+  mixing of `ERA5` and `ERA5T` data returned from the CDSAPI.
+  See `#190 <https://github.com/PyPSA/atlite/issues/190>`_ for details.
 
 Version 0.2.9
 =============

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -91,6 +91,14 @@ def _rename_and_clean_coords(ds, add_lon_lat=True):
     ds = maybe_swap_spatial_dims(ds)
     if add_lon_lat:
         ds = ds.assign_coords(lon=ds.coords["x"], lat=ds.coords["y"])
+
+    # Combine ERA5 and ERA5T data into a single dimension.
+    # See https://github.com/PyPSA/atlite/issues/190
+    if "expver" in ds.dims.keys():
+        # expver=1 is ERA5 data, expver=5 is ERA5T data
+        # This combines both by filling in NaNs from ERA5 data with values from ERA5T.
+        ds = ds.sel(expver=1).combine_first(ds.sel(expver=5))
+
     return ds
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #190.

## Change proposed in this Pull Request

<!--- Provide a general, short summary of your changes in the title above -->

## Description
Requesting cutout data spanning recent (ERA5T) and data older than ~3 months (ERA5) results in an additional dimension in `cutout.data`, called `expver`, which `atlite` currently cannot handle gracefully.

This change collapses the two dimensions into a single dimension.

## Motivation and Context
See details in #190.

## How Has This Been Tested?
The first commit of this pull request introduces a failing test that demonstrates the bug. The second commit fixes the bug and makes the failing test pass.

~**IMPORTANT**: the test introduced in the first commit **should not be merged** into `master`. The test data is time-dependent. Data which is ERA5T today will become ERA5 in the future. I only added the test for illustration. See the discussion in this pull request for alternative test proposals.~ (This has been resolved)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
