### PR TITLE
ease rasterio restriction

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -22,7 +22,7 @@ dependencies:
 - geopandas
 - cdsapi
 - pyproj>=2.0
-- rasterio>1.2.10
+- rasterio!=1.2.10
 - shapely
 - progressbar2
 - tqdm

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "toolz",
         "requests",
         "pyyaml",
-        "rasterio>1.2.10",
+        "rasterio!=1.2.10",
         "shapely",
         "progressbar2",
         "tqdm",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Only 1.2.10 created issues in Atlite see https://github.com/PyPSA/atlite/pull/240. 
My last stable PyPSA-Earth environment required rasterio 1.2.9.
So suggestion to ease restriction
