### PR TITLE
Switch from GPLv3 to more liberal MIT for atlite

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright 2017-2021 The PyPSA-Eur Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Similar to PyPSA and PyPSA-EUR we would like to change the license for atlite from the copyleft GNU General Public License Version 3 (GPLv3) to the more liberal MIT License.
This change is suggested because the benefits of a more liberal license seem to outweigh the benefits of a copyleft approach.

For a discussion of the benefits of either license see https://github.com/PyPSA/PyPSA/pull/274 but also please feel free to also discuss below.

This change requires the consent of all people who have substantially contributed code to atlite.
If you consent, please reply with a ✔️ below. If you do not consent, please reply with a ❌ below. Please respond by 11 December 2022.

Thanks for your help and contributions!


## Consent Essential (>= 20 lines of code)
@coroa
@FabianHofmann 
@euronion 
@nworbmot 
@LukasFrankenQ 
@pz-max 
@fneum 
@thesethtruth 
@schlachtberger 
@zoltanmaric 

## Consent Appreciated (< 20 lines of code)
@calvintr 
@davide-f 
@p-glaum 
@hailiangliu89 
@Ovewh 
@RichardScottOZ 
@brynpickering 
@leonsn 


(I'll update the PR if everyone has agreed to the license switch later to include all the necessary changes to files for the license switch to be complete)