### PR TITLE
remove deprecated grid functions

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -15,7 +15,7 @@ Upcoming Release
 * With this release, we change the license from copyleft GPLv3 to the more liberal MIT license with the consent of all major contributors `#263 <https://github.com/PyPSA/atlite/pull/263>`_.
 * Added 1-axis vertical and 2-axis tracking option for solar pv and trigon_model = "simple"
 * Added small documentation for get_windturbineconfig
-
+* The deprecated functions `grid_cells` and `grid_coordinates` were removed.
 
 Version 0.2.10
 ==============

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -350,31 +350,6 @@ class Cutout:
         index = pd.MultiIndex.from_tuples(index, names=["module", "feature"])
         return pd.Series(list(self.data), index, dtype=object)
 
-    def grid_coordinates(self):
-        """Array of grid coordinates, deprecated since v0.2.1."""
-        warn(
-            "The function `grid_coordinates` has been deprecated in favour of "
-            "`grid`",
-            DeprecationWarning,
-        )
-        logger.warning(
-            "The order of elements returned by `grid_coordinates` changed. "
-            "Check the output of your workflow for correctness."
-        )
-        return self.grid[["x", "y"]].values
-
-    def grid_cells(self):
-        """List of grid cells, deprecated since v0.2.1."""
-        warn(
-            "The function `grid_cells` has been deprecated in favour of `grid`",
-            DeprecationWarning,
-        )
-        logger.warning(
-            "The order of elements in `grid_cells` changed. "
-            "Check the output of your workflow for correctness."
-        )
-        return self.grid.geometry.to_list()
-
     @CachedAttribute
     def grid(self):
         """


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

The function are deprecated since version v0.2.1

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [ ] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [ ] I have used `pre-commit run --all` to lint/format/check my contribution
