### PR TITLE
Wind data from COSMO REA6 reanalysis

### DIFF
--- a/atlite/datasets/__init__.py
+++ b/atlite/datasets/__init__.py
@@ -4,6 +4,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-from atlite.datasets import era5, gebco, sarah
+from atlite.datasets import cosmo_rea6, era5, gebco, sarah
 
-modules = {"era5": era5, "sarah": sarah, "gebco": gebco}
+modules = {
+    "era5": era5,
+    "sarah": sarah,
+    "gebco": gebco,
+    "cosmo_rea6": cosmo_rea6,
+}

--- a/atlite/datasets/cosmo_rea6.py
+++ b/atlite/datasets/cosmo_rea6.py
@@ -39,15 +39,15 @@ dy = 0.0545
 dt = "1h"
 features = {
     "wind": [
-        "wnd10m",
-        "wnd40m",
-        "wnd60m",
-        "wnd80m",
-        "wnd100m",
+        # "wnd10m",
+        # "wnd40m",
+        # "wnd60m",
+        # "wnd80m",
+        # "wnd100m",
         "wnd125m",
-        "wnd150m",
+        # "wnd150m",
         "wnd175m",
-        "wnd200m",
+        # "wnd200m",
         "roughness",
     ],
 }
@@ -539,13 +539,6 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_params):
             * 'cosmo_rea6_dir': str of Path
             Directory of the stored COMSO REA6 data.
         Possible arguments are:
-            * 'cosmo_rea6_height_levels' : list[int]
-                If this argument is given, only selected height levels will be loaded.
-                Has to be a list of ints. Possible height levels are 10, 40, 60, 80,
-                100, 125, 150, 175, and 200 m.
-                .. warning::
-                    Currently it is not possible to reload initially unselected height
-                    levels once the Cutout is prepared.
             * 'parallel', bool.
                 Whether to load stored files in parallel mode. Default is False.
             * 'try_download' : bool
@@ -563,14 +556,7 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_params):
     creation_params.setdefault("parallel", False)
     creation_params.setdefault("try_download", True)
 
-    if "cosmo_rea6_height_levels" in creation_params.keys():
-        levels = [
-            _height_to_subfeature(x)
-            for x in creation_params["cosmo_rea6_height_levels"]
-        ]
-        logging.info(f"only using height levels {levels}")
-    else:
-        levels = features["wind"]
+    levels = features["wind"]
 
     ds = get_data_wind(
         cutout,

--- a/atlite/datasets/cosmo_rea6.py
+++ b/atlite/datasets/cosmo_rea6.py
@@ -46,7 +46,7 @@ features = {
         # "wnd100m",
         "wnd125m",
         # "wnd150m",
-        "wnd175m",
+        # "wnd175m",
         # "wnd200m",
         "roughness",
     ],

--- a/atlite/datasets/cosmo_rea6.py
+++ b/atlite/datasets/cosmo_rea6.py
@@ -1,0 +1,582 @@
+# -*- coding: utf-8 -*-
+
+# SPDX-FileCopyrightText: 2023 - 2023 The Atlite Authors
+#
+# SPDX-License-Identifier: MIT
+"""
+Module for downloading and preparing data from COSMO REA6 reanalysis.
+"""
+from __future__ import annotations
+
+import bz2
+import logging
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import requests
+import xarray as xr
+from rasterio.warp import Resampling
+from scipy.interpolate import griddata
+from tqdm import tqdm
+
+from atlite.gis import get_coords, regrid
+
+# avoid circular imports for type hints
+# https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/
+if TYPE_CHECKING:
+    from atlite import Cutout
+
+
+logger = logging.getLogger(__name__)
+logging.captureWarnings(True)
+
+# Model, CRS and Resolution Settings
+crs = 4326
+dx = 0.0875
+dy = 0.0545
+dt = "1h"
+features = {
+    "wind": [
+        "wnd10m",
+        "wnd40m",
+        "wnd60m",
+        "wnd80m",
+        "wnd100m",
+        "wnd125m",
+        "wnd150m",
+        "wnd175m",
+        "wnd200m",
+        "roughness",
+    ],
+}
+static_features = {}
+
+
+def build_filename(
+    year: int,
+    month: int,
+    dt: Literal[
+        "daily", "1D", "D", "hourly", "1H", "H", "monthly", "1M", "M", "1MS", "MS"
+    ],
+    height: Literal[10, 40, 60, 80, 100, 125, 150, 175, 200],
+) -> str:
+    """
+    Reconstruct a filename used on the opendata.dwd.de server.
+
+    Parameters
+    ----------
+    year : int
+        _description_
+    month : int
+        _description_
+    dt : Literal[&quot;daily&quot;, &quot;1D&quot;, &quot;D&quot;, &quot;hourly&quot;, &quot;1H&quot;, &quot;H&quot;, &quot;monthly&quot;, &quot;1M&quot;, &quot;M&quot;, &quot;1MS&quot;, &quot;MS&quot;]
+        _description_
+    height : Literal[10, 40, 60, 80, 100, 125, 150, 175, 200]
+        _description_
+
+    Returns
+    -------
+    str
+    """
+    assert dt in [
+        "daily",
+        "1D",
+        "D",
+        "hourly",
+        "1H",
+        "H",
+        "monthly",
+        "1M",
+        "M",
+        "1MS",
+        "MS",
+    ]
+    assert year in range(1995, 2020)
+    if year == 2019:  # data only until August available
+        assert month in range(1, 9), "COSMO REA6: 2019 only months Jan-Aug available"
+    else:
+        assert month in range(1, 13)
+    available_heights = (10, 40, 60, 80, 100, 125, 150, 175, 200)
+    assert height in available_heights, (
+        f"wind height level {height} not available in COSMO REA6\n"
+        f"available height levels are {available_heights}"
+    )
+
+    if dt in ["hourly", "1H", "H"]:
+        file_suffix = ".nc4"
+    elif dt in ["daily", "1D", "D"]:
+        file_suffix = ".DayMean.nc4"
+    elif dt in ["monthly", "1M", "M", "1MS", "MS"]:
+        file_suffix = ".MonMean.nc"
+
+    filename = f"WS_{height:03d}m.2D.{year}{month:02d}{file_suffix}"
+    return filename
+
+
+def download_file(
+    download_url: str, filepath: str | Path, show_progress: bool = True
+) -> None:
+    """
+    Savely download a large file from a URL.
+
+    If the download is interrupted, the incompletely downloaded  file will be deleted.
+
+    Parameters
+    ----------
+    download_url : str
+        URL where the file is located online.
+    filepath : str | Path
+        Local path where the file should be saved
+    show_progress : bool, optional
+        Whether to show a progressbar, by default True
+    """
+    try:
+        with requests.get(download_url, stream=True) as r:
+            r.raise_for_status()
+            if show_progress:
+                with tqdm.wrapattr(
+                    open(filepath, "wb"),
+                    "write",
+                    miniters=1,
+                    desc=download_url.split("/")[-1],
+                    total=int(r.headers.get("content-length", 0)),
+                ) as f:
+                    for chunk in r.iter_content(chunk_size=4096):
+                        f.write(chunk)
+            else:
+                with open(filepath, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        # If you have chunk encoded response uncomment if
+                        # and set chunk_size parameter to None.
+                        # if chunk:
+                        f.write(chunk)
+
+        logger.info(f"download complete, file saved to\n{filepath}")
+    except KeyboardInterrupt:
+        # open and close again to free the incompletely downloaded file:
+        with open(filepath, "rb") as f:
+            pass
+        # delete the incompletely downloaded file
+        filepath.unlink()
+        raise KeyboardInterrupt
+
+
+def maybe_download_file(
+    download_url: str, filepath: str | Path, show_progress: bool = True
+) -> None:
+    """
+    Check if local file exists, otherwise download the file.
+
+    If the download is interrupted, the incompletely downloaded file will be deleted.
+
+    Parameters
+    ----------
+    download_url : str
+        URL where the file is located online.
+    filepath : str | Path
+        Local path where the file should be saved
+    show_progress : bool, optional
+        Whether to show a progressbar, by default True
+    """
+    if Path(filepath).exists():
+        logger.info(f"skipping download: {filepath} exists already")
+    else:
+        download_file(download_url, filepath, show_progress)
+
+
+def maybe_download_COSMO_constant(out_dir: str | Path) -> Path:
+    """
+    Downloads the constant data from COMSO REA6 if it does not already exist in
+    `out_dir.`
+
+    Parameters
+    ----------
+    out_dir : str or Path
+        directory where the file should be searched and saved for.
+
+    Returns
+    -------
+    filepath : Path
+        filepath of the downloaded file
+    """
+    url = "https://opendata.dwd.de/climate_environment/REA/COSMO_REA6/constant/COSMO_REA6_CONST_withOUTsponge.nc.bz2"
+    zipfile_path = Path(out_dir) / "COSMO_REA6_CONST_withOUTsponge.nc.bz2"
+    filepath = Path(out_dir) / "COSMO_REA6_CONST_withOUTsponge.nc"
+
+    if filepath.exists():
+        logger.info("static COSMO REA6 fields already downloaded")
+
+    else:
+        download_file(url, zipfile_path)
+        # decompress bz2 file:
+        with open(filepath, "wb") as new_file, bz2.BZ2File(zipfile_path, "rb") as file:
+            for data in iter(lambda: file.read(100 * 1024), b""):
+                new_file.write(data)
+        # delete zip file
+        zipfile_path.unlink()
+
+    return filepath
+
+
+def download_wind_from_opendata_dwd(
+    year: int,
+    month: int,
+    dt: Literal[
+        "daily", "1D", "D", "hourly", "1H", "H", "monthly", "1M", "M", "1MS", "MS"
+    ],
+    height: Literal[10, 40, 60, 80, 100, 125, 150, 175, 200],
+    out_dir: str | Path,
+    show_progress: bool = True,
+) -> Path:
+    """
+    Download wind data from opendata.dwd.de.
+
+    Parameters
+    ----------
+    year : int
+        from 1995 to 2019
+    month : int
+        Month of the year
+    dt : str in {"daily", "hourly", "monthly"}
+        time resolution
+    height : int
+        Height above ground, possible values are
+        (10, 40, 60, 80, 100, 125, 150, 175, 200)
+    out_dir : str or Path
+        directory where to store the file
+    show_progress : bool
+        Whether download progress is shown or not
+
+    Returns
+    -------
+    filepath : Path
+        path and name where the file has been downloaded to.
+    """
+    filename = build_filename(int(year), int(month), dt, height)
+    filepath = Path(out_dir) / filename
+    # common url path for all converted REA6 fields
+    base_url = "https://opendata.dwd.de/climate_environment/REA/COSMO_REA6/converted"
+    # url for wind speed at a given height on opendata.dwd.de
+    if dt in ["hourly", "1H", "H"]:
+        dt_dwd = "hourly"
+    elif dt in ["daily", "1D", "D"]:
+        dt_dwd = "daily"
+    elif dt in ["monthly", "1M", "M", "1MS", "MS"]:
+        dt_dwd = "monthly"
+    file_dir_url = f"{base_url}/{dt_dwd}/2D/WS_{height:03d}/"
+    # url pointing to the netcdf file on opendata.dwd.de
+    download_url = f"{file_dir_url}{filename}"
+    maybe_download_file(download_url, filepath, show_progress)
+    return filepath
+
+
+def _subfeature_to_heigt(subfeature_string: str) -> int:
+    return int("".join(x for x in subfeature_string if x.isdigit()))
+
+
+def _height_to_subfeature(height: int) -> str:
+    return f"wnd{int(height)}m"
+
+
+def get_filenames(
+    cosmo_rea6_dir: str | Path,
+    cutout: Cutout,
+    subfeature: Literal[
+        "wnd10m",
+        "wnd40m",
+        "wnd60m",
+        "wnd80m",
+        "wnd100m",
+        "wnd125m",
+        "wnd150m",
+        "wnd175m",
+        "wnd200m",
+    ],
+    try_download: bool,
+) -> list[Path]:
+    """
+    Get all files in the COSMO REA6 data directory that match the required
+    height level, temporal resolution and time range.
+
+    Parameters
+    ----------
+    cosmo_rea6_dir : str
+    cutout : atlite.Cutout
+    subfeature : str
+        Subfeature sring decoding the height of the wind speed Needs to have the form
+        "wnd{height}m".
+    try_download : bool
+        Wheter the required files should be downloaded from atlite or manually from the
+        user.
+
+    Returns
+    -------
+    files : list
+        list of all files required for the cutout temporal extent and the subfeature.
+        This list can be passed to `:func:xarray.open_mfdataset`
+    """
+    coords = cutout.coords
+    included_year_months = (
+        coords["time"].dt.year.to_series().astype(str)
+        + "_"
+        + coords["time"].dt.month.to_series().astype(str).str.zfill(2)
+    ).unique()
+
+    files = []
+    for ym in included_year_months:
+        if try_download:
+            files.append(
+                download_wind_from_opendata_dwd(
+                    year=ym.split("_")[0],
+                    month=ym.split("_")[1],
+                    dt=cutout.dt,
+                    height=_subfeature_to_heigt(subfeature),
+                    out_dir=cosmo_rea6_dir,
+                    show_progress=True,
+                )
+            )
+        else:
+            files.append(
+                Path(cosmo_rea6_dir)
+                / build_filename(
+                    year=ym.split("_")[0],
+                    month=ym.split("_")[1],
+                    dt=cutout.dt,
+                    height=_subfeature_to_heigt(subfeature),
+                )
+            )
+
+    for f in files:
+        if not f.exists():
+            warnings.warn(
+                (
+                    f"{f} is not downloaded yet and will not be added to cutout.\n\nPlease "
+                    "download it manually from"
+                    "https://opendata.dwd.de/climate_environment/REA/COSMO_REA6/converted"
+                    "or set 'try_download=True'"
+                )
+            )
+    return files
+
+
+def regrid_to_rectilinear(
+    ds: xr.Dataset,
+    cutout: Cutout,
+    data_variable: str,
+) -> xr.Dataset:
+    """
+    Regrid the curvilinear COMSO grid to rectilinear grid used in atlite.
+
+    Parameters
+    ----------
+    ds : _type_
+        _description_
+    cutout : _type_
+        _description_
+    data_variable : _type_
+        _description_
+
+    Returns
+    -------
+    _type_
+        _description_
+
+    Raises
+    ------
+    ValueError
+        _description_
+    """
+    x1, x2, y1, y2 = cutout.extent
+    # get dataset with coords with more or less equal spacing as in COSMO REA6
+    ds_regridded = get_coords(
+        x=slice(x1, x2),
+        y=slice(y1, y2),
+        time=slice(
+            cutout.coords["time"].min().values, cutout.coords["time"].max().values
+        ),
+        dx=dx,  # use mean dx from COSMO curvilinear grid
+        dy=dy,  # use mean dy from COSMO curvilinear grid
+        dt=cutout.dt,
+    )
+
+    xx, yy = np.meshgrid(ds_regridded.x.values, ds_regridded.y.values)
+
+    if len(ds[data_variable].dims) == 3:
+        assert len(ds_regridded["time"]) == len(ds["time"])
+        arr = (
+            np.zeros((len(ds_regridded.y), len(ds_regridded.x), len(ds_regridded.time)))
+            * np.nan
+        )
+
+        # slow loop over time dimension
+        for i, t in enumerate(
+            tqdm(
+                ds_regridded["time"],
+                desc=f"transforming {data_variable} to rectilinear grid",
+            )
+        ):
+            try:
+                arr[:, :, i] = griddata(
+                    points=(ds["RLON"].values.flatten(), ds["RLAT"].values.flatten()),
+                    values=ds[data_variable].sel(time=t).values.flatten(),
+                    xi=(xx, yy),
+                    method="nearest",
+                )
+            except KeyError:
+                # cosmo starts at 01:00:00 of a day, get_coords() at 00:00:00
+                pass
+
+        ds_regridded[data_variable] = xr.DataArray(
+            data=arr,
+            coords={
+                "y": ds_regridded.y,
+                "x": ds_regridded.x,
+                "time": ds_regridded.time,
+            },
+            attrs=ds[data_variable].attrs,
+        )
+    elif len(ds[data_variable].dims) == 2:
+        arr = np.zeros((len(ds_regridded.y), len(ds_regridded.x))) * np.nan
+
+        arr[:, :] = griddata(
+            points=(ds["RLON"].values.flatten(), ds["RLAT"].values.flatten()),
+            values=ds[data_variable].values.flatten(),
+            xi=(xx, yy),
+            method="nearest",
+        )
+
+        ds_regridded[data_variable] = xr.DataArray(
+            data=arr,
+            coords={"y": ds_regridded.y, "x": ds_regridded.x},
+            attrs=ds[data_variable].attrs,
+        )
+    else:
+        raise ValueError("DataArray to be regridded needs to be 2D or 3D.")
+
+    return ds_regridded
+
+
+def get_roughness_subfeature(cutout: Cutout, cosmo_rea6_dir: str | Path) -> xr.Dataset:
+    file = maybe_download_COSMO_constant(cosmo_rea6_dir)
+    ds = xr.open_dataset(file)
+    ds = regrid_to_rectilinear(ds, cutout, "Z0")
+    ds = ds.rename({"Z0": "roughness"})
+    return ds
+
+
+def get_wind_heightlevel_subfeature(
+    subfeature: str,
+    cutout: Cutout,
+    cosmo_rea6_dir: str | Path,
+    try_download: bool,
+    parallel: bool,
+) -> xr.Dataset:
+    files = get_filenames(
+        cosmo_rea6_dir,
+        cutout,
+        subfeature,
+        try_download=try_download,
+    )
+
+    open_kwargs = dict(chunks=cutout.chunks, parallel=parallel)
+    ds = xr.open_mfdataset(files, combine="by_coords", **open_kwargs)
+    ds = regrid_to_rectilinear(ds, cutout, "wind_speed")
+    ds = ds.rename({"wind_speed": subfeature})
+    return ds
+
+
+def get_data_wind(
+    cutout: Cutout,
+    height_levels: list[str],
+    cosmo_rea6_dir: str | Path,
+    try_download: bool,
+    parallel: bool,
+) -> xr.Dataset:
+    subfeature_ds_list = []
+    for subfeature in height_levels:
+        logger.info(f"preparing wind subfeature '{subfeature}'")
+        if subfeature.startswith("wnd"):
+            subfeature_ds_list.append(
+                get_wind_heightlevel_subfeature(
+                    subfeature,
+                    cutout,
+                    cosmo_rea6_dir,
+                    try_download,
+                    parallel,
+                )
+            )
+        else:  # roughness
+            subfeature_ds_list.append(
+                get_roughness_subfeature(
+                    cutout,
+                    cosmo_rea6_dir,
+                )
+            )
+
+    ds = xr.merge(subfeature_ds_list)
+
+    coords = cutout.coords
+    if (cutout.dx != dx) or (cutout.dy != dy):
+        ds = regrid(ds, coords["lon"], coords["lat"], resampling=Resampling.average)
+    return ds
+
+
+def get_data(cutout, feature, tmpdir, lock=None, **creation_params):
+    """
+    This function (down)loads COSMO REA6 data and regrids it to match a given
+    `:class:atlite.Cutout`.
+
+    Parameters
+    ----------
+    cutout : atlite.Cutout
+    feature : str
+        Name of the feature data to retrieve. Must be in
+        `atlite.datasets.cosmo_rea6.features`
+    **creation_parameters :
+        Mandatory arguments are:
+            * 'cosmo_rea6_dir': str of Path
+            Directory of the stored COMSO REA6 data.
+        Possible arguments are:
+            * 'cosmo_rea6_height_levels' : list[int]
+                If this argument is given, only selected height levels will be loaded.
+                Has to be a list of ints. Possible height levels are 10, 40, 60, 80,
+                100, 125, 150, 175, and 200 m.
+                .. warning::
+                    Currently it is not possible to reload initially unselected height
+                    levels once the Cutout is prepared.
+            * 'parallel', bool.
+                Whether to load stored files in parallel mode. Default is False.
+            * 'try_download' : bool
+                Whether a data file should be downloaded from opendata.dwd.de if it is
+                not available in `cosmo_rea6_dir`.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset with the retrieved variables.
+    """
+    assert cutout.dt in ("1D", "D", "1H", "H", "1M", "M", "1MS", "MS")
+    assert "cosmo_rea6_dir" in creation_params.keys()
+
+    creation_params.setdefault("parallel", False)
+    creation_params.setdefault("try_download", True)
+
+    if "cosmo_rea6_height_levels" in creation_params.keys():
+        levels = [
+            _height_to_subfeature(x)
+            for x in creation_params["cosmo_rea6_height_levels"]
+        ]
+        logging.info(f"only using height levels {levels}")
+    else:
+        levels = features["wind"]
+
+    ds = get_data_wind(
+        cutout,
+        levels,
+        creation_params["cosmo_rea6_dir"],
+        creation_params["try_download"],
+        creation_params["parallel"],
+    )
+    return ds


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Change proposed in this Pull Request
<!--- Provide a general, short summary of your changes in the title above -->
Once ready, this pull requests would add the possibility to include wind data from the COSMO REA6 reanalysis into atlite. This is a first version which I made for a specific use-case. It is already working for my needs (i.e. on a small spatial domain in central Europe) but is neither robust nor tested exhaustively. If you think this adds value to atlite and would be good to be included, I can try to continue working on it and make it more robust, make the regridding faster, add tests etc.

## Description
<!--- Describe your changes in detail -->
A new module `cosmo_rea6` is added to `atlite.datasets`. The module can download data from the opendata.dwd server and restructures the data in order to fit into the atlite framework and conventions. Only the wind feature is supported. 

A dedicated directory to store the downloaded raw netcdfs was chosen instead of tempdir approach as in the era5 module. This allows users to download the data however they want and then reuse it in atlite without letting atlite handle the download.

## Issues, Questions and Todos
- As there are many height levels available from the dwd server, it would be nice if the user could select only needed height levels and not load the complete `wind` feature with all levels. I tried to intruduce a creation_paramter `cosmo_rea6_height_levels` but this is not working due to the way missing (sub)features are searched in [`data.cutout_prepare()`](https://github.com/joAschauer/atlite/blob/2e84b5fa15ae05b12a7598a32a7a36e9e69488db/atlite/data.py#L112). Is there an easy way of selecting subfeatures for a Cutout? Another way would be to preselect avaliable height levels in the `features` list of the `comso_rea6` module which would then not be available to the users (what I did now for testing purposes).

- The COSMO data is provided on a curvilinear grid with rotated pole. For the wind speed on https://opendata.dwd.de/climate_environment/REA/COSMO_REA6/converted data, 2D coordinate fields are already provided in WGS84. In order to work with atlite (compatibility with other datasets, layout capacity mapping), regridding to a rectilinear grid is necessary. As far as I understood, this is something different as done in `atlite.gis.regrid` and unfortunately on I didn't find an easy way for doing it on a windows platform (see https://github.com/pydata/xarray/issues/2281) while it would have been easily possible on linux (e.g. with xESMF https://xesmf.readthedocs.io/en/latest/notebooks/Curvilinear_grid.html). Therefore, [I implemented a hacky solution with `scipy.griddata`](https://github.com/joAschauer/atlite/blob/2240377ac96814c473d8f0498615c3e7cd19ce5a/atlite/datasets/cosmo_rea6.py#L364) which is terribly slow for now. I guess this should be sorted out before merging, atleast xr.apply_ufunc should be used somehow.

- Right now, no checks are done whether the cutout extent is within the COSMO REA6 domain. I need to check if the regridding is working when the domain is larger than the COSMO domain.

- I did not test whether it is easily possible to combine the `cosmo_rea6` module with other data modules such as `era5` and `sarah`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The COSMO REA6 reanalysis is a regional reanalysis product for Europe. It has a spatial resolution of ~6km and is able to represent local wind speeds significantly better than e.g. ERA5 (see Kaspar et al. 2020, https://doi.org/10.5194/asr-17-115-2020 for a review). However, Urraca et al. (2018, https://doi.org/10.1016/j.solener.2018.02.059) conclude that satellite based products such as SARAH are performing better than COSMO REA6 for radiation. Therefore, it probably only makes sense to include wind from COSMO REA6 into atlite which is what this PR does.

On the opendata.dwd.de server, wind speed at 10, 40, 60, 80, 100, 125, 150, 175 and 200 m height above ground is available at daily and hourly resolution (e.g. https://opendata.dwd.de/climate_environment/REA/COSMO_REA6/converted/hourly/2D/).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I only created a dedicated wind cutout for 2012 in Germany and reproduced [this example from the documenation](https://atlite.readthedocs.io/en/latest/examples/historic-comparison-germany.html). Below you can see the same plots as in the example that compare the different data sources.
![time_series_DE_2012](https://github.com/PyPSA/atlite/assets/38501948/415eaac9-0c20-4dec-8434-b113f5391135)
![time_series_DE_2012-04](https://github.com/PyPSA/atlite/assets/38501948/a21cfebe-465f-488e-8546-ed46ea1de5d6)
![scatter_DE_2012](https://github.com/PyPSA/atlite/assets/38501948/b3cc09e2-f462-49a8-81ab-350dbc839cba)
![duration_curves_DE_2012](https://github.com/PyPSA/atlite/assets/38501948/740d715b-be7a-4843-8979-477bbb0bbe37)

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [ ] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution