### PR TITLE
let `add_geometry` and `add_raster` read from URL

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,7 +12,7 @@ Release Notes
 Upcoming Release
 ================
 
-* The functions ``add_raster()`` and ``add_geometry()`` of the ``ExclusionContainer`` can now directly read from URL. 
+* The functions ``add_raster()`` and ``add_geometry()`` of the ``ExclusionContainer`` can now directly read from URL.
 
 
 Version 0.2.11

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -9,8 +9,11 @@ Release Notes
 
 
 
-.. Upcoming Release
-.. ================
+Upcoming Release
+================
+
+* The functions ``add_raster()`` and ``add_geometry()`` of the ``ExclusionContainer`` can now directly read from URL. 
+
 
 Version 0.2.11
 ==============

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -8,14 +8,13 @@ Functions for Geographic Information System.
 """
 
 import logging
-import os
-import validators
 import multiprocessing as mp
+import os
 from collections import OrderedDict
 from functools import wraps
 from pathlib import Path
-from warnings import catch_warnings, simplefilter, warn
 from urllib.request import urlretrieve
+from warnings import catch_warnings, simplefilter, warn
 
 import geopandas as gpd
 import numpy as np
@@ -24,6 +23,7 @@ import rasterio as rio
 import rasterio.warp
 import scipy as sp
 import scipy.sparse
+import validators
 import xarray as xr
 from numpy import empty, isin
 from pyproj import CRS, Transformer

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
 - numpy
 - scipy
 - pandas>=0.25
-- xarray>=0.16.2
+- xarray>=0.20
 - netcdf4
 - dask>=2021.10.0
 - toolz
@@ -26,6 +26,7 @@ dependencies:
 - shapely
 - progressbar2
 - tqdm
+- validators
 
   # dev tools
 - black

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "pyproj>=2",
         "geopandas",
         "cdsapi",
+        "validators",
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
Closes #307 

Popular feature request in the Data Science for Energy System Modelling course.

Follows PyPSA implementation.

Test with:

```py
import geopandas as gpd
from atlite.gis import ExclusionContainer

URL = 'https://tubcloud.tu-berlin.de/s/mxgaA7wH8NsmdDi/download/Natura2000_end2021-PT.gpkg'
CRS = 3035

world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
shape = world.query("iso_a3 == 'PRT'").to_crs(CRS).geometry

excluder = ExclusionContainer(crs=CRS)
excluder.add_geometry(URL)

excluder.plot_shape_availability(shape)
```