### PR TITLE
fix: power curves with missing cutoff

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -12,6 +12,11 @@ Release Notes
 .. Upcoming Release
 .. ================
 
+.. * Fix: the wind turbine power curve is checked for a missing cut-out wind speed and an option to add a
+..   cut-out wind speed at the end of the power curve is introduced. From the next release v0.2.13, adding
+..   a cut-out wind speed will be the default behavior (`GH #316 <https://github.com/PyPSA/atlite/pull/316>`_)
+
+
 Version 0.2.11
 ==============
 

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -480,7 +480,7 @@ def convert_wind(ds, turbine):
     return da
 
 
-def wind(cutout, turbine, smooth=False, add_cutoff=False, **params):
+def wind(cutout, turbine, smooth=False, add_cutout_windspeed=False, **params):
     """
     Generate wind generation time-series.
 
@@ -501,10 +501,10 @@ def wind(cutout, turbine, smooth=False, add_cutoff=False, **params):
         If True smooth power curve with a gaussian kernel as
         determined for the Danish wind fleet to Delta_v = 1.27 and
         sigma = 2.29. A dict allows to tune these values.
-    add_cutoff : bool
+    add_cutout_windspeed : bool
         If True and in case the power curve does not end with a zero, will add zero power
         output at the highest wind speed in the power curve. If False, a warning will be
-        raised if the power curve does not have a cutoff wind speed. The default is
+        raised if the power curve does not have a cut-out wind speed. The default is
         False.
 
     Note
@@ -518,7 +518,9 @@ def wind(cutout, turbine, smooth=False, add_cutoff=False, **params):
     1074 – 1088. doi:10.1016/j.energy.2015.09.071
     """
     if isinstance(turbine, (str, Path, dict)):
-        turbine = get_windturbineconfig(turbine, add_cutoff=add_cutoff)
+        turbine = get_windturbineconfig(
+            turbine, add_cutout_windspeed=add_cutout_windspeed
+        )
 
     if smooth:
         turbine = windturbine_smooth(turbine, params=smooth)

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -461,15 +461,6 @@ def convert_wind(ds, turbine):
     """
     V, POW, hub_height, P = itemgetter("V", "POW", "hub_height", "P")(turbine)
 
-    if POW[-1] != 0:
-        logger.warning(
-            (
-                "The power curve does not have a cutoff speed i.e. the last value is "
-                "not zero.\nYou can either change the power curve manually or set "
-                "'add_cutoff=True' in the Cutout.wind conversion method."
-            )
-        )
-
     wnd_hub = windm.extrapolate_wind_speed(ds, to_height=hub_height)
 
     def _interpolate(da):
@@ -511,8 +502,10 @@ def wind(cutout, turbine, smooth=False, add_cutoff=False, **params):
         determined for the Danish wind fleet to Delta_v = 1.27 and
         sigma = 2.29. A dict allows to tune these values.
     add_cutoff : bool
-        If True, will add a zero power output at the highest wind speed in the power
-        curve in case the power curve does ot end with a zero.
+        If True and in case the power curve does not end with a zero, will add zero power
+        output at the highest wind speed in the power curve. If False, a warning will be
+        raised if the power curve does not have a cutoff wind speed. The default is
+        False.
 
     Note
     ----
@@ -524,21 +517,11 @@ def wind(cutout, turbine, smooth=False, add_cutoff=False, **params):
     [1] Andresen G B, Søndergaard A A and Greiner M 2015 Energy 93, Part 1
     1074 – 1088. doi:10.1016/j.energy.2015.09.071
     """
-    if isinstance(turbine, (str, Path)):
-        turbine = get_windturbineconfig(turbine)
+    if isinstance(turbine, (str, Path, dict)):
+        turbine = get_windturbineconfig(turbine, add_cutoff=add_cutoff)
 
     if smooth:
         turbine = windturbine_smooth(turbine, params=smooth)
-
-    if add_cutoff and turbine["POW"][-1] != 0:
-        turbine["V"] = np.pad(turbine["V"], (0, 1), "edge")
-        turbine["POW"] = np.pad(turbine["POW"], (0, 1), "constant", constant_values=0)
-        logger.info(
-            (
-                "adding a cutoff wind speed to the turbine power curve at"
-                f"V={turbine['V'][-1]} m/s."
-            )
-        )
 
     return cutout.convert_and_aggregate(
         convert_func=convert_wind, turbine=turbine, **params

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -11,6 +11,7 @@ panel configurations.
 import json
 import logging
 import re
+import warnings
 from operator import itemgetter
 from pathlib import Path
 
@@ -32,13 +33,13 @@ SOLARPANEL_DIRECTORY = RESOURCE_DIRECTORY / "solarpanel"
 CSPINSTALLATION_DIRECTORY = RESOURCE_DIRECTORY / "cspinstallation"
 
 
-def get_windturbineconfig(turbine):
+def get_windturbineconfig(turbine, add_cutoff=False):
     """
     Load the wind 'turbine' configuration.
 
     Parameters
     ----------
-    turbine : str or pathlib.Path
+    turbine : str or pathlib.Path or dict
         if str:
             The name of a preshipped turbine from alite.resources.windturbine .
             Alternatively, if a str starting with 'oedb:<name>' is passed the Open
@@ -47,32 +48,52 @@ def get_windturbineconfig(turbine):
             `atlite.resource.get_oedb_windturbineconfig(...)`
         if `pathlib.Path` is provided the configuration is read from this local
             path instead
+        if dict:
+            a user provided config dict. Needs to have the keys "POW", "V", "P", and
+            "hub_height". Values for "POW" and "V" need to be list or np.ndarray with
+            equal length.
+    add_cutoff : bool
+        If True and in case the power curve does not end with a zero, will add zero power
+        output at the highest wind speed in the power curve. If False, a warning will be
+        raised if the power curve does not have a cutoff wind speed.
 
     Returns
     ----------
     config : dict
         Config with details on the turbine
     """
-    assert isinstance(turbine, (str, Path))
+    assert isinstance(turbine, (str, Path, dict))
+
+    if add_cutoff is False:
+        msg = (
+            "'add_cutoff' for wind turbine\npower curves will default to True in a "
+            "future version of atlite."
+        )
+        warnings.warn(msg, FutureWarning)
 
     if isinstance(turbine, str) and turbine.startswith("oedb:"):
-        return get_oedb_windturbineconfig(turbine[len("oedb:") :])
+        conf = get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
-    elif isinstance(turbine, str):
-        turbine_path = windturbines[turbine.replace(".yaml", "")]
+    elif isinstance(turbine, (str, Path)):
+        if isinstance(turbine, str):
+            turbine_path = windturbines[turbine.replace(".yaml", "")]
 
-    elif isinstance(turbine, Path):
-        turbine_path = turbine
+        elif isinstance(turbine, Path):
+            turbine_path = turbine
 
-    with open(turbine_path, "r") as f:
-        conf = yaml.safe_load(f)
+        with open(turbine_path, "r") as f:
+            conf = yaml.safe_load(f)
+            conf = dict(
+                V=np.array(conf["V"]),
+                POW=np.array(conf["POW"]),
+                hub_height=conf["HUB_HEIGHT"],
+                P=np.max(conf["POW"]),
+            )
 
-    return dict(
-        V=np.array(conf["V"]),
-        POW=np.array(conf["POW"]),
-        hub_height=conf["HUB_HEIGHT"],
-        P=np.max(conf["POW"]),
-    )
+    elif isinstance(turbine, dict):
+        conf = turbine
+
+    return _validate_turbine_config_dict(conf, add_cutoff)
 
 
 def get_solarpanelconfig(panel):
@@ -257,6 +278,71 @@ def windturbine_smooth(turbine, params=None):
             sigma,
         )
 
+    return turbine
+
+
+def _max_v_is_zero_pow(turbine):
+    return np.any((turbine["POW"][turbine["V"] == turbine["V"].max()] == 0))
+
+
+def _validate_turbine_config_dict(turbine: dict, add_cutoff: bool):
+    """
+    Checks the turbine config dict format and power curve.
+
+    Parameters
+    ----------
+    turbine : dict
+        turbine configuration dict. Needs the keys "POW", "V", "P", and "hub_height".
+        Values for "V" and "POW" need to be list or np.ndarray.
+    add_cutoff : bool
+        If True and in case the power curve does not end with a zero, will add zero power
+        output at the highest wind speed in the power curve. If False, a warning will be
+        raised if the power curve does not have a cutoff wind speed.
+
+    Returns
+    -------
+    dict
+        validated and potentially modified turbine config dict
+    """
+    if not all(key in turbine for key in ("POW", "V", "P", "hub_height")):
+        err_msg = (
+            "turbine config dict needs at least the following keys: ['POW', 'V', 'P', "
+            f"'hub_height']\nbut are currently: {list(turbine.keys())}"
+        )
+        raise ValueError(err_msg)
+
+    if not all(isinstance(turbine[p], (np.ndarray, list)) for p in ("POW", "V")):
+        raise ValueError("turbine entries 'POW' and 'V' must be np.ndarray or list")
+
+    # convert lists from user provided turbine dicts to numpy arrays
+    if any(isinstance(turbine[p], list) for p in ("POW", "V")):
+        turbine["V"] = np.array(turbine["V"])
+        turbine["POW"] = np.array(turbine["POW"])
+
+    if len(turbine["POW"]) != len(turbine["V"]):
+        raise ValueError(
+            "turbine wind speed and power arrays do not have equal length."
+        )
+
+    if add_cutoff is True and not _max_v_is_zero_pow(turbine):
+        turbine["V"] = np.pad(turbine["V"], (0, 1), "maximum")
+        turbine["POW"] = np.pad(turbine["POW"], (0, 1), "constant", constant_values=0)
+        logger.info(
+            (
+                "adding a cutoff wind speed to the turbine power curve at "
+                f"V={turbine['V'][-1]} m/s."
+            )
+        )
+
+    if not _max_v_is_zero_pow(turbine):
+        logger.warning(
+            (
+                "The power curve does not have a cutoff speed, i.e. the power output "
+                "corresponding to the\nhighest wind speed is not zero. You can either "
+                "change the power curve manually or set\n'add_cutoff=True' in the "
+                "Cutout.wind conversion method."
+            )
+        )
     return turbine
 
 

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -66,8 +66,8 @@ def get_windturbineconfig(turbine, add_cutout_windspeed=False):
 
     if add_cutout_windspeed is False:
         msg = (
-            "'add_cutout_windspeed' for wind turbine\npower curves will default to True in a "
-            "future version of atlite."
+            "'add_cutout_windspeed' for wind turbine\npower curves will default to "
+            "True in atlite relase v0.2.13."
         )
         warnings.warn(msg, FutureWarning)
 

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -11,7 +11,7 @@ Created on Tue Jun 22 10:46:27 2021.
 """
 import pytest
 
-from atlite.resource import get_oedb_windturbineconfig
+from atlite.resource import get_oedb_windturbineconfig, get_windturbineconfig
 
 
 def test_oedb_windturbineconfig():
@@ -23,3 +23,12 @@ def test_oedb_windturbineconfig():
 
     # test string search with param
     assert get_oedb_windturbineconfig("E-101/3500 E2", hub_height=99)
+
+
+@pytest.mark.parametrize("add_cutout, last_pow", [(True, 0.0), (False, 1.0)])
+def test_windturbineconfig_add_cutout(add_cutout, last_pow):
+    t = get_windturbineconfig(
+        {"V": [0, 25], "POW": [0.0, 1.0], "hub_height": 1.0, "P": 1.0},
+        add_cutout_windspeed=add_cutout,
+    )
+    assert t["POW"][-1] == last_pow


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #314

## Change proposed in this Pull Request

<!--- Provide a general, short summary of your changes in the title above -->
First proposal to fix #314. It is still to discuss if the appended cutoff wind speed should be slightly higher than the last entry in the power curve. Currently, np.interp will lead to 0 if the exact cutoff wind speed is met.

## Description
<!--- Describe your changes in detail -->
- `convert_wind()` function throws a warning if the power curve has no cutoff for high wind speeds i.e. if the last value is not zero.
- `Cutout.wind()` method now has a new argument `add_cutoff`. When set to True, this will modify the power curve by inserting a zero at the highest wind speed in the power curve. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see #314.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not really yet.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [ ] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
