### PR TITLE
Add helper function ``area`` and ``layout_from_area_density`` & allow auto chunks

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -28,7 +28,9 @@ Upcoming Release
 * Fix: the wind turbine power curve is checked for a missing cut-out wind speed and an option to add a
   cut-out wind speed at the end of the power curve is introduced. From the next release v0.2.13, adding
   a cut-out wind speed will be the default behavior (`GH #316 <https://github.com/PyPSA/atlite/pull/316>`_)
-
+* A cutout can now be loaded with setting chunks to ``auto``.
+* The Cutout class has a new function ``area`` which return a DataArray with dimensions (x,y) with the area of each grid cell.
+* The Cutout class has a new function ``layout_from_area_density`` which returns a capacity layout with the capacity per grid cell based on the area density.
 
 Version 0.2.11
 ==============

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -575,7 +575,7 @@ class Cutout:
         ----------
         crs : int, optional
             The coordinate reference system (CRS) to use for the calculation.
-            The default value is 3035, which is a suitable projection for Europe and returns the area in square meters.
+            Defaults to the crs of the cutout.
 
         Returns
         -------
@@ -607,7 +607,7 @@ class Cutout:
             Capacity density in capacity/projection unit squared.
         crs : int, optional
             CRS to calculate the total area of grid cells.
-            Defaults to the crs of the cutout.
+            Passed to `Cutout.area()`.
 
         Returns
         -------

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -150,7 +150,10 @@ class Cutout:
 
         path = Path(path).with_suffix(".nc")
         chunks = cutoutparams.pop("chunks", {"time": 100})
-        storable_chunks = {f"chunksize_{k}": v for k, v in (chunks or {}).items()}
+        if isinstance(chunks, dict):
+            storable_chunks = {f"chunksize_{k}": v for k, v in (chunks or {}).items()}
+        else:
+            storable_chunks = {}
 
         # Backward compatibility for xs, ys, months and years
         if {"xs", "ys"}.intersection(cutoutparams):
@@ -564,6 +567,26 @@ class Cutout:
         """
         return compute_intersectionmatrix(self.grid, shapes, self.crs, shapes_crs)
 
+    def area(self, crs=3035):
+        """
+        Get the area per grid cell as a DataArray with coords (x,y).
+
+        Parameters
+        ----------
+        crs : int, optional
+            CRS to calculate the total area of grid cells in m^2.
+            The default is 3035 which is suitable for the European area.
+
+        Returns
+        -------
+        None.
+        """
+        area = self.grid.to_crs(crs).area.div(1e6)
+        return xr.DataArray(
+            area.values.reshape(self.shape),
+            [self.coords["y"], self.coords["x"]],
+        )
+
     def uniform_layout(self):
         """
         Get a uniform capacity layout for all grid cells.
@@ -617,6 +640,27 @@ class Cutout:
             .sum()
         )
         return data.to_xarray().reindex_like(self.data).fillna(0)
+
+    def layout_from_area_density(self, capacity_density, crs=3035):
+        """
+        Get a capacity layout from a uniform capacity density.
+
+        Parameters
+        ----------
+        capacity_density : float
+            Capacity density in capacity/km^2
+        crs : int, optional
+            CRS to calculate the total area of grid cells in m^2.
+            The default is 3035 which is suitable for the European area.
+
+        Returns
+        -------
+        xr.DataArray
+            Capacity layout with dimensions 'x' and 'y' indicating the total
+            capacity placed within one grid cell.
+        """
+
+        return capacity_density * self.area(crs)
 
     availabilitymatrix = compute_availabilitymatrix
 

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -567,7 +567,7 @@ class Cutout:
         """
         return compute_intersectionmatrix(self.grid, shapes, self.crs, shapes_crs)
 
-    def area(self, crs=3035):
+    def area(self, crs=None):
         """
         Get the area per grid cell as a DataArray with coords (x,y).
 
@@ -582,6 +582,9 @@ class Cutout:
         xr.DataArray
             A DataArray containing the area per grid cell with coordinates (x,y).
         """
+        if crs is None:
+            crs = self.crs
+
         area = self.grid.to_crs(crs).area
         return xr.DataArray(
             area.values.reshape(self.shape),
@@ -593,6 +596,26 @@ class Cutout:
         Get a uniform capacity layout for all grid cells.
         """
         return xr.DataArray(1, [self.coords["y"], self.coords["x"]])
+
+    def uniform_density_layout(self, capacity_density, crs=None):
+        """
+        Get a capacity layout from a uniform capacity density.
+
+        Parameters
+        ----------
+        capacity_density : float
+            Capacity density in capacity/projection unit squared.
+        crs : int, optional
+            CRS to calculate the total area of grid cells.
+            Defaults to the crs of the cutout.
+
+        Returns
+        -------
+        xr.DataArray
+            Capacity layout with dimensions 'x' and 'y' indicating the total
+            capacity placed within one grid cell.
+        """
+        return capacity_density * self.area(crs)
 
     def layout_from_capacity_list(self, data, col="Capacity"):
         """
@@ -641,27 +664,6 @@ class Cutout:
             .sum()
         )
         return data.to_xarray().reindex_like(self.data).fillna(0)
-
-    def layout_from_area_density(self, capacity_density, crs=3035):
-        """
-        Get a capacity layout from a uniform capacity density.
-
-        Parameters
-        ----------
-        capacity_density : float
-            Capacity density in capacity/km^2
-        crs : int, optional
-            CRS to calculate the total area of grid cells in m^2.
-            The default is 3035 which is suitable for the European area.
-
-        Returns
-        -------
-        xr.DataArray
-            Capacity layout with dimensions 'x' and 'y' indicating the total
-            capacity placed within one grid cell.
-        """
-
-        return capacity_density * self.area(crs) / 1e6
 
     availabilitymatrix = compute_availabilitymatrix
 

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -574,14 +574,15 @@ class Cutout:
         Parameters
         ----------
         crs : int, optional
-            CRS to calculate the total area of grid cells in m^2.
-            The default is 3035 which is suitable for the European area.
+            The coordinate reference system (CRS) to use for the calculation.
+            The default value is 3035, which is a suitable projection for Europe and returns the area in square meters.
 
         Returns
         -------
-        None.
+        xr.DataArray
+            A DataArray containing the area per grid cell with coordinates (x,y).
         """
-        area = self.grid.to_crs(crs).area.div(1e6)
+        area = self.grid.to_crs(crs).area
         return xr.DataArray(
             area.values.reshape(self.shape),
             [self.coords["y"], self.coords["x"]],
@@ -660,7 +661,7 @@ class Cutout:
             capacity placed within one grid cell.
         """
 
-        return capacity_density * self.area(crs)
+        return capacity_density * self.area(crs) / 1e6
 
     availabilitymatrix = compute_availabilitymatrix
 

--- a/test/test_creation.py
+++ b/test/test_creation.py
@@ -114,3 +114,11 @@ def test_sel(ref):
     cutout = ref.sel(x=slice(X0 + 2, X1 - 1), y=slice(Y0 + 1, Y1 - 2))
     assert cutout.coords["x"][0] - ref.coords["x"][0] == 2
     assert cutout.coords["y"][-1] - ref.coords["y"][-1] == -2
+
+
+def test_layout_from_area_density(ref):
+    density = 0.1
+    layout = ref.layout_from_area_density(density)
+    assert layout.dims == ("y", "x")
+    assert layout.shape == (ref.data.y.size, ref.data.x.size)
+    assert ref.area().sum() * density / 1e6 == layout.sum()

--- a/test/test_creation.py
+++ b/test/test_creation.py
@@ -69,6 +69,18 @@ def test_time_sclice_coords(ref):
     assert_equal(cutout.coords.to_dataset(), ref.coords.to_dataset())
 
 
+def test_auto_chunking(ref):
+    cutout = Cutout(
+        path="auto_chunking",
+        module="era5",
+        time=slice("2013-01-01", "2013-01-01"),
+        x=slice(X0, X1),
+        y=slice(Y0, Y1),
+        chunks="auto",
+    )
+    assert_equal(cutout.coords.to_dataset(), ref.coords.to_dataset())
+
+
 def test_dx_dy_dt():
     """
     Test the properties dx, dy, dt of atlite.Cutout.

--- a/test/test_creation.py
+++ b/test/test_creation.py
@@ -134,4 +134,4 @@ def test_layout_from_area_density(ref):
     layout = ref.uniform_density_layout(density, crs=crs)
     assert layout.dims == ("y", "x")
     assert layout.shape == (ref.data.y.size, ref.data.x.size)
-    assert ref.area(crs=crs).sum() * density == layout.sum()
+    assert np.isclose(ref.area(crs=crs).sum() * density, layout.sum())

--- a/test/test_creation.py
+++ b/test/test_creation.py
@@ -129,8 +129,9 @@ def test_sel(ref):
 
 
 def test_layout_from_area_density(ref):
-    density = 0.1
-    layout = ref.layout_from_area_density(density)
+    density = 0.01  # MW / m^2
+    crs = 3035  # in meter
+    layout = ref.uniform_density_layout(density, crs=crs)
     assert layout.dims == ("y", "x")
     assert layout.shape == (ref.data.y.size, ref.data.x.size)
-    assert ref.area().sum() * density / 1e6 == layout.sum()
+    assert ref.area(crs=crs).sum() * density == layout.sum()

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -200,6 +200,21 @@ def test_open_closed_checks(ref, geometry, raster):
     assert not excluder.all_closed and excluder.all_open
 
 
+def test_area(ref):
+    """
+    Test the area of the cutout.
+    """
+    area = ref.area()
+    assert isinstance(area, xr.DataArray)
+    assert area.dims == ("y", "x")
+
+    # now test with a different crs
+    with pytest.warns(UserWarning):
+        assert ref.area(crs=ref.crs).sum().item() == (X1 - X0 + ref.dx) * (
+            Y1 - Y0 + ref.dy
+        )
+
+
 def test_transform():
     """
     Test the affine transform.

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -204,15 +204,13 @@ def test_area(ref):
     """
     Test the area of the cutout.
     """
-    area = ref.area()
+    area = ref.area(crs=3035)
     assert isinstance(area, xr.DataArray)
     assert area.dims == ("y", "x")
 
     # now test with a different crs
     with pytest.warns(UserWarning):
-        assert ref.area(crs=ref.crs).sum().item() == (X1 - X0 + ref.dx) * (
-            Y1 - Y0 + ref.dy
-        )
+        assert ref.area().sum().item() == (X1 - X0 + ref.dx) * (Y1 - Y0 + ref.dy)
 
 
 def test_transform():


### PR DESCRIPTION
 - add functions `area` & `layout_from_area_density`
 - allow for `auto` chunks when loading cutout

## Motivation and Context

The ``area`` function is helpful for custom workflows, the same with the new layout function.

The auto chunking **can** help to accelerate the computation of the conversion functions. 

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
