### PR TITLE
CF timeseries per gridcell

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -125,7 +125,7 @@ def convert_and_aggregate(
                 "One of `matrix`, `shapes` and `layout` must be "
                 "given for `per_unit` or `return_capacity`"
             )
-        if capacity_factor:
+        if capacity_factor or capacity_factor_timeseries:
             if capacity_factor_timeseries:
                 res = da.rename("capacity factor")
             else:

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -50,6 +50,7 @@ def convert_and_aggregate(
     per_unit=False,
     return_capacity=False,
     capacity_factor=False,
+    capacity_factor_timeseries=False,
     show_progress=True,
     dask_kwargs={},
     **convert_kwds,
@@ -87,6 +88,9 @@ def convert_and_aggregate(
     capacity_factor : boolean
         If True, the static capacity factor of the chosen resource for each
         grid cell is computed.
+    capacity_factor_timeseries : boolean
+        If True, the capacity factor time series of the chosen resource for
+        each grid cell is computed.
     show_progress : boolean, default True
         Whether to show a progress bar.
     dask_kwargs : dict, default {}
@@ -122,7 +126,10 @@ def convert_and_aggregate(
                 "given for `per_unit` or `return_capacity`"
             )
         if capacity_factor:
-            res = da.mean("time").rename("capacity factor")
+            if capacity_factor_timeseries:
+                res = da.rename("capacity factor")
+            else:
+                res = da.mean("time").rename("capacity factor")
             res.attrs["units"] = "p.u."
             return maybe_progressbar(res, show_progress, **dask_kwargs)
         else:

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -8,3 +8,6 @@
 * In ``atlite/resource.py``, the functions ``get_windturbineconfig``, ``get_solarpanelconfig``, and
   ``get_cspinstallationconfig`` will now recognize if a local file was passed, and if so load
   it instead of one of the predefined ones.
+
+* The option ``capacity_factor_timeseries`` can be selected when creating capacity factors to obtain
+ the capacity factor of the selected resource per grid cell. 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -10,4 +10,4 @@
   it instead of one of the predefined ones.
 
 * The option ``capacity_factor_timeseries`` can be selected when creating capacity factors to obtain
- the capacity factor of the selected resource per grid cell. 
+ the capacity factor of the selected resource per grid cell.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->


## Description
It can be useful to get access to the hourly capacity factor per grid cell. 
this small addition to convert_and_agregate allows it. 


## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [x] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
