### PR TITLE
Feature/add dewpoint temperature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Atlite can process the following weather data fields and can convert them into f
 .. * Surface roughness
 .. * Height maps
 .. * Soil temperature
+.. * Dewpoint temperature
 
 
 .. * Wind power generation for a given turbine type

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -247,11 +247,7 @@ def convert_dewpoint_temperature(ds):
     Return dewpoint temperature.
     """
     # Temperature is in Kelvin
-
-    # There are nans where there is sea; by setting them
-    # to zero we guarantee they do not contribute when multiplied
-    # by matrix in atlite/aggregate.py
-    return (ds["dewpoint temperature"] - 273.15).fillna(0.0)
+    return ds["dewpoint temperature"] - 273.15
 
 
 def dewpoint_temperature(cutout, **params):

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -241,6 +241,25 @@ def soil_temperature(cutout, **params):
     return cutout.convert_and_aggregate(convert_func=convert_soil_temperature, **params)
 
 
+# dewpoint temperature
+def convert_dewpoint_temperature(ds):
+    """
+    Return dewpoint temperature.
+    """
+    # Temperature is in Kelvin
+
+    # There are nans where there is sea; by setting them
+    # to zero we guarantee they do not contribute when multiplied
+    # by matrix in atlite/aggregate.py
+    return (ds["dewpoint temperature"] - 273.15).fillna(0.0)
+
+
+def dewpoint_temperature(cutout, **params):
+    return cutout.convert_and_aggregate(
+        convert_func=convert_dewpoint_temperature, **params
+    )
+
+
 def convert_coefficient_of_performance(ds, source, sink_T, c0, c1, c2):
     assert source in ["air", "soil"], NotImplementedError(
         "'source' must be one of  ['air', 'soil']"

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -35,6 +35,7 @@ from atlite.convert import (
     coefficient_of_performance,
     convert_and_aggregate,
     csp,
+    dewpoint_temperature,
     heat_demand,
     hydro,
     irradiation,
@@ -680,6 +681,8 @@ class Cutout:
     temperature = temperature
 
     soil_temperature = soil_temperature
+
+    dewpoint_temperature = dewpoint_temperature
 
     coefficient_of_performance = coefficient_of_performance
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -53,7 +53,7 @@ features = {
         "solar_altitude",
         "solar_azimuth",
     ],
-    "temperature": ["temperature", "soil temperature"],
+    "temperature": ["temperature", "soil temperature", "dewpoint temperature"],
     "runoff": ["runoff"],
 }
 
@@ -199,11 +199,22 @@ def get_data_temperature(retrieval_params):
     Get wind temperature for given retrieval parameters.
     """
     ds = retrieve_data(
-        variable=["2m_temperature", "soil_temperature_level_4"], **retrieval_params
+        variable=[
+            "2m_temperature",
+            "soil_temperature_level_4",
+            "2m_dewpoint_temperature",
+        ],
+        **retrieval_params,
     )
 
     ds = _rename_and_clean_coords(ds)
-    ds = ds.rename({"t2m": "temperature", "stl4": "soil temperature"})
+    ds = ds.rename(
+        {
+            "t2m": "temperature",
+            "stl4": "soil temperature",
+            "d2m": "dewpoint temperature",
+        }
+    )
 
     return ds
 

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -273,6 +273,16 @@ def soil_temperature_test(cutout):
     assert demand.sum() > 0
 
 
+def dewpoint_temperature_test(cutout):
+    """
+    Test the atlite.Cutout.dewpoint_temperature function with different
+    settings.
+    """
+    demand = cutout.dewpoint_temperature()
+    assert demand.notnull().all()
+    assert demand.sum() > 0
+
+
 def wind_test(cutout):
     """
     Test the atlite.Cutout.wind function with two different layouts.
@@ -683,6 +693,10 @@ class TestERA5:
     @staticmethod
     def test_soil_temperature_era5(cutout_era5):
         return soil_temperature_test(cutout_era5)
+
+    @staticmethod
+    def test_dewpoint_temperature_era5(cutout_era5):
+        return dewpoint_temperature_test(cutout_era5)
 
     @staticmethod
     def test_line_rating_era5(cutout_era5):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes # (if applicable).

## Change proposed in this Pull Request

Adds dewpoint temperature to the list of features fetched from ERA5. 

It is possible that existing data pipelines that expect only 2 variables for the temperature may experience breaks with the addition of the new column. Should this new feature be optional instead ?



## Description
Added the dewpoint_temperature variable, consistent with the processing of existing temperature and soil temperature variables

## Motivation and Context
Dewpoint temperature is a good indicator of climate comfort and predictor of electricity demand. 

## How Has This Been Tested?
Tested by preparing a Cutout from ERA5, verifying the dew point temperature is included.
Tested on python 3.10.12

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I tested my contribution locally and it seems to work fine.
- [x] I locally ran `pytest` inside the repository and no unexpected problems came up.
- [x] I have adjusted the docstrings in the code appropriately.
- [ ] I have documented the effects of my code changes in the documentation `doc/`.
- [x] I have added newly introduced dependencies to `environment.yaml` file.
- [x] I have added a note to release notes `doc/release_notes.rst`.
- [x] I have used `pre-commit run --all` to lint/format/check my contribution
