### PR TITLE
fix: disable_progressbar in compute_availabilitymatrix

### DIFF
--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -727,10 +727,27 @@ def compute_availabilitymatrix(
         total=len(shapes),
         desc="Compute availability matrix",
     )
+
     if nprocesses is None:
+        logger.info(
+            "You can disable the progress bar by setting 'disable_progressbar=True'."
+        )
+
+        if not disable_progressbar:
+            tqdm_kwargs = dict(
+                ascii=False,
+                unit=" gridcells",
+                total=len(shapes),
+                desc="Compute availability matrix",
+            )
+            iterator = tqdm(shapes.index, **tqdm_kwargs)
+        else:
+            logger.info("Progress bar is disabled.")
+            iterator = shapes.index
+
         with catch_warnings():
             simplefilter("ignore")
-            for i in tqdm(shapes.index, **tqdm_kwargs):
+            for i in iterator:
                 _ = shape_availability_reprojected(shapes.loc[[i]], *args)[0]
                 availability.append(_)
     else:

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -729,22 +729,10 @@ def compute_availabilitymatrix(
     )
 
     if nprocesses is None:
-        logger.info(
-            "You can disable the progress bar by setting 'disable_progressbar=True'."
-        )
-
         if not disable_progressbar:
-            tqdm_kwargs = dict(
-                ascii=False,
-                unit=" gridcells",
-                total=len(shapes),
-                desc="Compute availability matrix",
-            )
             iterator = tqdm(shapes.index, **tqdm_kwargs)
         else:
-            logger.info("Progress bar is disabled.")
             iterator = shapes.index
-
         with catch_warnings():
             simplefilter("ignore")
             for i in iterator:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

## Changes proposed in this Pull Request

The function `compute_availabilitymatrix()` includes an option to disable the progress bar (`disable_progressbar`). However, for non-parallel computation path (i.e., when `nprocesses` is `None`, the code uses `tqdm` directly, w/o passing the `disable_progressbar` check.  This PR fixes it. User is informed if progress bar is disabled.

Why bother: it seems that **progress bar makes computation much slower**. For a test case (UA, solar availability matrix, local computation, nprocesses is None) disabling progress bar speeds the process from **2000 seconds to 760 seconds.** 
Similar behavior was observed for other atlite processes, such as `build_renewable_profiles` (rumor evidence).

Closes #[pypsa-eur/1090](https://github.com/PyPSA/pypsa-eur/issues/1090)

## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.


