### PR TITLE
era5: update to new CDS infrastructure

### DIFF
--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -99,7 +99,7 @@ def _rename_and_clean_coords(ds, add_lon_lat=True):
     # Combine ERA5 and ERA5T data into a single dimension.
     # See https://github.com/PyPSA/atlite/issues/190
     if "expver" in ds.coords:
-        unique_expver = np.unique(ds['expver'].values)
+        unique_expver = np.unique(ds["expver"].values)
         if len(unique_expver) > 1:
             expver_dim = xr.DataArray(
                 unique_expver, dims=["expver"], coords={"expver": unique_expver}
@@ -115,7 +115,7 @@ def _rename_and_clean_coords(ds, add_lon_lat=True):
             # expver=1 is ERA5 data, expver=5 is ERA5T data This combines both
             # by filling in NaNs from ERA5 data with values from ERA5T.
             ds = ds.sel(expver="0001").combine_first(ds.sel(expver="0005"))
-    ds = ds.drop_vars(["expver", "number"], errors='ignore')
+    ds = ds.drop_vars(["expver", "number"], errors="ignore")
 
     return ds
 


### PR DESCRIPTION
closes #361 

This PR is backwards compatible; old CDS infrastructure can still be used.

Other things needed to update:

- follow instructions https://forum.ecmwf.int/t/the-new-climate-data-store-beta-cds-beta-is-now-live/3315
- retrieve new `~/.cdsapirc`
- update to `cdsapi>=0.7.0`

Main changes:
- The time variable was renamed in CDS from "time" to "valid_time", which is renamed in `_rename_and_clean_coords()`
- A useless "number" coordinate was added, which is removed in `_rename_and_clean_coords()`.
- There was some weirdness in the "expver" coordinate when ERA5 and ERA5T data were mixed (coordinate but not a dimension). Also, it seems that the "expver" coordinate is now always created and is a 4-digit string rather than an integer. If somebody has a leaner suggestion here, I am all ears. It was quite tricky as non-`xarray` expert. 

If we want to use new CDS infrastructure in CI, the secrets need to be updated. Perhaps we shouldn't do this immediately.

Furthermore, I am not sure how to remove the plentiful INFO logs.