### PR TITLE
toggle for (concurrent) monthly ERA5 requests; progressbar disabled by default 

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -11,6 +11,10 @@ Release Notes
 Upcoming Release
 ================
 
+- Adds option to toggle whether ERA5 downloads are requested in monthly or
+  annual chunks with keyword argument ``cutout.prepare(monthly_requests=True)``.
+  The default is now annual requests.
+
 - Improved parallelization of ``atlite.convert.build_line_rating`` by adding
   keyword arguments for ``dask.compute`` (``dask_kwargs={}``) and an option to
   disable the progressbar (``show_progressbar=True``).

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -19,7 +19,9 @@ Upcoming Release
 
 - Improved parallelization of ``atlite.convert.build_line_rating`` by adding
   keyword arguments for ``dask.compute`` (``dask_kwargs={}``) and an option to
-  disable the progressbar (``show_progressbar=True``).
+  disable the progressbar (``show_progress=False``).
+
+- Default to ``show_progress=False`` for performance reasons.
 
 Version 0.2.13
 ==============

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -13,7 +13,9 @@ Upcoming Release
 
 - Adds option to toggle whether ERA5 downloads are requested in monthly or
   annual chunks with keyword argument ``cutout.prepare(monthly_requests=True)``.
-  The default is now annual requests.
+  The default is now annual requests. The monthly requests can also be posted
+  concurrently using ``cutout.prepare(monthly_requests=True,
+  concurrent_requests=True)``.
 
 - Improved parallelization of ``atlite.convert.build_line_rating`` by adding
   keyword arguments for ``dask.compute`` (``dask_kwargs={}``) and an option to

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -51,7 +51,7 @@ def convert_and_aggregate(
     return_capacity=False,
     capacity_factor=False,
     capacity_factor_timeseries=False,
-    show_progress=True,
+    show_progress=False,
     dask_kwargs={},
     **convert_kwds,
 ):
@@ -91,7 +91,7 @@ def convert_and_aggregate(
     capacity_factor_timeseries : boolean
         If True, the capacity factor time series of the chosen resource for
         each grid cell is computed.
-    show_progress : boolean, default True
+    show_progress : boolean, default False
         Whether to show a progress bar.
     dask_kwargs : dict, default {}
         Dict with keyword arguments passed to `dask.compute`.
@@ -882,7 +882,7 @@ def hydro(
     hydrobasins,
     flowspeed=1,
     weight_with_height=False,
-    show_progress=True,
+    show_progress=False,
     **kwargs,
 ):
     """
@@ -1047,7 +1047,7 @@ def convert_line_rating(
 
 
 def line_rating(
-    cutout, shapes, line_resistance, show_progress=True, dask_kwargs={}, **params
+    cutout, shapes, line_resistance, show_progress=False, dask_kwargs={}, **params
 ):
     """
     Create a dynamic line rating time series based on the IEEE-738 standard.
@@ -1073,7 +1073,7 @@ def line_rating(
     line_resistance : float/series
         Resistance of the lines in Ohm/meter. Alternatively in p.u. system in
         Ohm/1000km (see example below).
-    show_progress : boolean, default True
+    show_progress : boolean, default False
         Whether to show a progress bar.
     dask_kwargs : dict, default {}
         Dict with keyword arguments passed to `dask.compute`.

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -25,7 +25,14 @@ logger = logging.getLogger(__name__)
 from atlite.datasets import modules as datamodules
 
 
-def get_features(cutout, module, features, tmpdir=None, monthly_requests=False):
+def get_features(
+    cutout,
+    module,
+    features,
+    tmpdir=None,
+    monthly_requests=False,
+    concurrent_requests=False,
+):
     """
     Load the feature data for a given module.
 
@@ -44,6 +51,7 @@ def get_features(cutout, module, features, tmpdir=None, monthly_requests=False):
             tmpdir=tmpdir,
             lock=lock,
             monthly_requests=monthly_requests,
+            concurrent_requests=concurrent_requests,
             **parameters,
         )
         datasets.append(feature_data)
@@ -121,6 +129,7 @@ def cutout_prepare(
     overwrite=False,
     compression={"zlib": True, "complevel": 9, "shuffle": True},
     monthly_requests=False,
+    concurrent_requests=False,
 ):
     """
     Prepare all or a selection of features in a cutout.
@@ -157,6 +166,9 @@ def cutout_prepare(
         If True, the data is requested on a monthly basis in ERA5. This is useful for
         large cutouts, where the data is requested in smaller chunks. The
         default is False
+    concurrent_requests : bool, optional
+        If True, the monthly data requests are posted concurrently.
+        Only has an effect if `monthly_requests` is True. The default is False.
 
     Returns
     -------
@@ -190,6 +202,7 @@ def cutout_prepare(
             missing_features,
             tmpdir=tmpdir,
             monthly_requests=monthly_requests,
+            concurrent_requests=concurrent_requests,
         )
         prepared |= set(missing_features)
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -447,9 +447,9 @@ def get_data(
 
     if feature in static_features:
         return retrieve_once(
-            retrieval_times(coords, static=True, monthly_requests=monthly_requests)
+            retrieval_times(coords, static=True)
         ).squeeze()
 
-    datasets = map(retrieve_once, retrieval_times(coords))
+    datasets = map(retrieve_once, retrieval_times(coords, monthly_requests=monthly_requests))
 
     return xr.concat(datasets, dim="time").sel(time=coords["time"])

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -20,8 +20,8 @@ import cdsapi
 import numpy as np
 import pandas as pd
 import xarray as xr
+from dask import compute, delayed
 from numpy import atleast_1d
-from dask import delayed, compute
 
 from atlite.gis import maybe_swap_spatial_dims
 from atlite.pv.solar_position import SolarPosition

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -274,7 +274,7 @@ def _area(coords):
     return [y1, x0, y0, x1]
 
 
-def retrieval_times(coords, static=False):
+def retrieval_times(coords, static=False, monthly_requests=False):
     """
     Get list of retrieval cdsapi arguments for time dimension in coordinates.
 
@@ -287,6 +287,11 @@ def retrieval_times(coords, static=False):
     Parameters
     ----------
     coords : atlite.Cutout.coords
+    static : bool, optional
+    monthly_requests : bool, optional
+        If True, the data is requested on a monthly basis. This is useful for
+        large cutouts, where the data is requested in smaller chunks. The
+        default is False
 
     Returns
     -------
@@ -305,12 +310,21 @@ def retrieval_times(coords, static=False):
     times = []
     for year in time.year.unique():
         t = time[time.year == year]
-        for month in t.month.unique():
+        if monthly_requests:
+            for month in t.month.unique():
+                query = {
+                    "year": str(year),
+                    "month": str(month),
+                    "day": list(t[t.month == month].day.unique()),
+                    "time": ["%02d:00" % h for h in t[t.month == month].hour.unique()],
+                }
+                times.append(query)
+        else:
             query = {
                 "year": str(year),
-                "month": str(month),
-                "day": list(t[t.month == month].day.unique()),
-                "time": ["%02d:00" % h for h in t[t.month == month].hour.unique()],
+                "month": list(t.month.unique()),
+                "day": list(t.day.unique()),
+                "time": ["%02d:00" % h for h in t.hour.unique()],
             }
             times.append(query)
     return times
@@ -377,7 +391,7 @@ def retrieve_data(product, chunks=None, tmpdir=None, lock=None, **updates):
     return ds
 
 
-def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
+def get_data(cutout, feature, tmpdir, lock=None, monthly_requests=False, **creation_parameters):
     """
     Retrieve data from ECMWFs ERA5 dataset (via CDS).
 
@@ -392,6 +406,10 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
         `atlite.datasets.era5.features`
     tmpdir : str/Path
         Directory where the temporary netcdf files are stored.
+    monthly_requests : bool, optional
+        If True, the data is requested on a monthly basis in ERA5. This is useful for
+        large cutouts, where the data is requested in smaller chunks. The
+        default is False
     **creation_parameters :
         Additional keyword arguments. The only effective argument is 'sanitize'
         (default True) which sets sanitization of the data on or off.
@@ -426,7 +444,9 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
         return ds
 
     if feature in static_features:
-        return retrieve_once(retrieval_times(coords, static=True)).squeeze()
+        return retrieve_once(
+            retrieval_times(coords, static=True, monthly_requests=monthly_requests)
+        ).squeeze()
 
     datasets = map(retrieve_once, retrieval_times(coords))
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -391,7 +391,9 @@ def retrieve_data(product, chunks=None, tmpdir=None, lock=None, **updates):
     return ds
 
 
-def get_data(cutout, feature, tmpdir, lock=None, monthly_requests=False, **creation_parameters):
+def get_data(
+    cutout, feature, tmpdir, lock=None, monthly_requests=False, **creation_parameters
+):
     """
     Retrieve data from ECMWFs ERA5 dataset (via CDS).
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -446,10 +446,10 @@ def get_data(
         return ds
 
     if feature in static_features:
-        return retrieve_once(
-            retrieval_times(coords, static=True)
-        ).squeeze()
+        return retrieve_once(retrieval_times(coords, static=True)).squeeze()
 
-    datasets = map(retrieve_once, retrieval_times(coords, monthly_requests=monthly_requests))
+    datasets = map(
+        retrieve_once, retrieval_times(coords, monthly_requests=monthly_requests)
+    )
 
     return xr.concat(datasets, dim="time").sel(time=coords["time"])

--- a/atlite/datasets/gebco.py
+++ b/atlite/datasets/gebco.py
@@ -45,7 +45,7 @@ def get_data_gebco_height(xs, ys, gebco_path):
     )
 
 
-def get_data(cutout, feature, tmpdir, monthly_requests=False, **creation_parameters):
+def get_data(cutout, feature, tmpdir, monthly_requests=False, concurrent_requests=False, **creation_parameters):
     """
     Get the gebco height data.
 
@@ -57,6 +57,8 @@ def get_data(cutout, feature, tmpdir, monthly_requests=False, **creation_paramet
     tmpdir : str
         Takes no effect, only here for consistency with other dataset modules.
     monthly_requests : bool
+        Takes no effect, only here for consistency with other dataset modules.
+    concurrent_requests : bool
         Takes no effect, only here for consistency with other dataset modules.
     **creation_parameters :
         Must include `gebco_path`.

--- a/atlite/datasets/gebco.py
+++ b/atlite/datasets/gebco.py
@@ -45,7 +45,14 @@ def get_data_gebco_height(xs, ys, gebco_path):
     )
 
 
-def get_data(cutout, feature, tmpdir, monthly_requests=False, concurrent_requests=False, **creation_parameters):
+def get_data(
+    cutout,
+    feature,
+    tmpdir,
+    monthly_requests=False,
+    concurrent_requests=False,
+    **creation_parameters
+):
     """
     Get the gebco height data.
 

--- a/atlite/datasets/gebco.py
+++ b/atlite/datasets/gebco.py
@@ -45,7 +45,7 @@ def get_data_gebco_height(xs, ys, gebco_path):
     )
 
 
-def get_data(cutout, feature, tmpdir, **creation_parameters):
+def get_data(cutout, feature, tmpdir, monthly_requests=False, **creation_parameters):
     """
     Get the gebco height data.
 
@@ -55,6 +55,8 @@ def get_data(cutout, feature, tmpdir, **creation_parameters):
     feature : str
         Takes no effect, only here for consistency with other dataset modules.
     tmpdir : str
+        Takes no effect, only here for consistency with other dataset modules.
+    monthly_requests : bool
         Takes no effect, only here for consistency with other dataset modules.
     **creation_parameters :
         Must include `gebco_path`.

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -160,7 +160,7 @@ def hourly_mean(ds):
     return ds
 
 
-def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
+def get_data(cutout, feature, tmpdir, lock=None, monthly_requests=False, **creation_parameters):
     """
     Load stored SARAH data and reformat to matching the given cutout.
 
@@ -173,6 +173,8 @@ def get_data(cutout, feature, tmpdir, lock=None, **creation_parameters):
     feature : str
         Name of the feature data to retrieve. Must be in
         `atlite.datasets.sarah.features`
+    monthly_requests : bool
+        Takes no effect, only here for consistency with other dataset modules.
     **creation_parameters :
         Mandatory arguments are:
             * 'sarah_dir', str. Directory of the stored SARAH data.

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -160,7 +160,9 @@ def hourly_mean(ds):
     return ds
 
 
-def get_data(cutout, feature, tmpdir, lock=None, monthly_requests=False, **creation_parameters):
+def get_data(
+    cutout, feature, tmpdir, lock=None, monthly_requests=False, **creation_parameters
+):
     """
     Load stored SARAH data and reformat to matching the given cutout.
 

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -177,6 +177,8 @@ def get_data(
         `atlite.datasets.sarah.features`
     monthly_requests : bool
         Takes no effect, only here for consistency with other dataset modules.
+    concurrent_requests : bool
+        Takes no effect, only here for consistency with other dataset modules.
     **creation_parameters :
         Mandatory arguments are:
             * 'sarah_dir', str. Directory of the stored SARAH data.

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -674,7 +674,7 @@ def _process_func(i):
 
 
 def compute_availabilitymatrix(
-    cutout, shapes, excluder, nprocesses=None, disable_progressbar=False
+    cutout, shapes, excluder, nprocesses=None, disable_progressbar=True
 ):
     """
     Compute the eligible share within cutout cells in the overlap with shapes.

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -41,7 +41,7 @@ def find_upstream_basins(meta, hid):
     return hids
 
 
-def determine_basins(plants, hydrobasins, show_progress=True):
+def determine_basins(plants, hydrobasins, show_progress=False):
     if isinstance(hydrobasins, str):
         hydrobasins = gpd.read_file(hydrobasins)
 
@@ -81,7 +81,7 @@ def determine_basins(plants, hydrobasins, show_progress=True):
 
 
 def shift_and_aggregate_runoff_for_plants(
-    basins, runoff, flowspeed=1, show_progress=True
+    basins, runoff, flowspeed=1, show_progress=False
 ):
     inflow = xr.DataArray(
         np.zeros((len(basins.plants), runoff.indexes["time"].size)),

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -677,7 +677,7 @@ class TestERA5:
         return pv_test(
             cutout, time=str(first_day_prev_month), skip_optimal_sum_test=True
         )
-    
+
     @staticmethod
     @pytest.mark.parametrize("concurrent_requests", [True, False])
     def test_era5_monthly_requests(tmp_path_factory, concurrent_requests):

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -677,6 +677,13 @@ class TestERA5:
         return pv_test(
             cutout, time=str(first_day_prev_month), skip_optimal_sum_test=True
         )
+    
+    @staticmethod
+    @pytest.mark.parametrize("concurrent_requests", [True, False])
+    def test_era5_monthly_requests(tmp_path_factory, concurrent_requests):
+        tmp_path = tmp_path_factory.mktemp("era5_mon")
+        cutout = Cutout(path=tmp_path / "era5", module="era5", bounds=BOUNDS, time=TIME)
+        cutout.prepare(monthly_requests=True, concurrent_requests=concurrent_requests)
 
     @staticmethod
     def test_wind_era5(cutout_era5):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 The Atlite Authors

SPDX-License-Identifier: CC0-1.0
-->

Closes #371.

## Changes proposed in this Pull Request

Adds option to toggle whether ERA5 downloads are requested in monthly or annual chunks with option to place concurrent requests with keyword argument `cutout.prepare(monthly_requests=False, concurrent_requests=False)`.

Potential performance improvements and functionality tests shown in #371.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] ~Unit tests for new features were added (if applicable).~
- [x] ~Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).~
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
