### PR TITLE
update reuse license and docs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 name: Bug Report

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 name: Bug Report
@@ -20,10 +20,10 @@ body:
     options:
     - label: >
         I have confirmed this bug exists on the lastest
-        [release](https://github.com/pypsa/atlite/releases) of Atlite.
+        [release](https://github.com/pypsa/atlite/releases) of atlite.
     - label: >
         I have confirmed this bug exists on the current
-        [`master`](https://github.com/pypsa/atlite/tree/master) branch of Atlite.
+        [`master`](https://github.com/pypsa/atlite/tree/master) branch of atlite.
 
 - type: textarea
   id: problem

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 <!---
-SPDX-FileCopyrightText: 2021 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: CC0-1.0
 --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 <!---
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: CC0-1.0
 --->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2021 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: CC0-1.0
 -->

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 name: Tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 name: Tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 ci:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 ci:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,13 +4,13 @@ Upstream-Contact: Jonas Hörsch <jonas.hoersch@posteo.de>
 Source: https://github.com/PyPSA/atlite
 
 Files: doc/img/*
-Copyright: 2019 - 2023 The Atlite Authors
+Copyright: Contributors to Atlite <https://github.com/pypsa/atlite>
 License: CC-BY-4.0
 
 Files: doc/workflow*
-Copyright: 2021 The Atlite Authors
+Copyright: Contributors to Atlite <https://github.com/pypsa/atlite>
 License: CC-BY-4.0
 
 Files: doc/examples/*.nblink
-Copyright: 2020 - 2023 The Atlite Authors
+Copyright: Contributors to Atlite <https://github.com/pypsa/atlite>
 License: CC-BY-4.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,16 +1,16 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Atlite
+Upstream-Name: atlite
 Upstream-Contact: Jonas Hörsch <jonas.hoersch@posteo.de>
 Source: https://github.com/PyPSA/atlite
 
 Files: doc/img/*
-Copyright: Contributors to Atlite <https://github.com/pypsa/atlite>
+Copyright: Contributors to atlite <https://github.com/pypsa/atlite>
 License: CC-BY-4.0
 
 Files: doc/workflow*
-Copyright: Contributors to Atlite <https://github.com/pypsa/atlite>
+Copyright: Contributors to atlite <https://github.com/pypsa/atlite>
 License: CC-BY-4.0
 
 Files: doc/examples/*.nblink
-Copyright: Contributors to Atlite <https://github.com/pypsa/atlite>
+Copyright: Contributors to atlite <https://github.com/pypsa/atlite>
 License: CC-BY-4.0

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: : 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 <!---
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: CC0-1.0
 --->
 
-Atlite's contributor guidelines can be found in the official [documentation](https://atlite.readthedocs.io/en/master/contributing.html).
+atlite's contributor guidelines can be found in the official [documentation](https://atlite.readthedocs.io/en/master/contributing.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!---
-SPDX-FileCopyrightText: 2021 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: CC0-1.0
 --->

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 - 2024 Contributors to atlite
+Copyright (c) Contributors to atlite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 - 2024 Contributors to Atlite
+Copyright (c) 2016 - 2024 Contributors to atlite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 - 2024 The Atlite Authors
+Copyright (c) 2016 - 2024 Contributors to Atlite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 - 2024 Contributors to atlite. All rights reserved.
+Copyright (c) Contributors to atlite. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 - 2024 Contributors to Atlite. All rights reserved.
+Copyright (c) 2016 - 2024 Contributors to atlite. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner>. All rights reserved.
+Copyright (c) 2016 - 2024 Contributors to Atlite. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,9 +1,21 @@
 MIT License
 
-Copyright (c) 2017 - 2023 The Atlite Authors
+Copyright (c) 2017 - 2024 Contributors to Atlite
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 - 2024 Contributors to Atlite
+Copyright (c) 2017 - 2024 Contributors to atlite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 - 2024 Contributors to atlite
+Copyright (c) Contributors to atlite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-  .. SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  .. SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   .. SPDX-License-Identifier: CC-BY-4.0
 
@@ -120,7 +120,7 @@ Support & Contributing
 Authors and Copyright
 ---------------------
 
-Copyright (C) 2016 - 2023 The Atlite Authors.
+Copyright (C) 2016 - 2024 Contributors to Atlite <https://github.com/pypsa/atlite>
 
 See the `AUTHORS`_ for details.
 
@@ -166,8 +166,8 @@ See the individual files for license details.
    :target: LICENSES/MIT.txt
 .. |codecov| image:: https://codecov.io/gh/PyPSA/atlite/branch/master/graph/badge.svg?token=TEJ16CMIHJ
    :target: https://codecov.io/gh/PyPSA/atlite
-.. |ci| image:: https://github.com/PyPSA/atlite/actions/workflows/CI.yaml/badge.svg
-   :target: https://github.com/PyPSA/atlite/actions/workflows/CI.yaml
+.. |ci| image:: https://github.com/PyPSA/atlite/actions/workflows/test.yaml/badge.svg
+   :target: https://github.com/PyPSA/atlite/actions/workflows/test.yaml
 .. |reuse| image:: https://api.reuse.software/badge/github.com/pypsa/atlite
    :target: https://api.reuse.software/info/github.com/pypsa/atlite
 .. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Support & Contributing
 Authors and Copyright
 ---------------------
 
-Copyright (C) 2016 - 2024 Contributors to atlite <https://github.com/pypsa/atlite>
+Copyright (C) Contributors to atlite <https://github.com/pypsa/atlite>
 
 See the `AUTHORS`_ for details.
 

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,19 @@
-  .. SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  .. SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   .. SPDX-License-Identifier: CC-BY-4.0
 
 ======
-Atlite
+atlite
 ======
 
 |PyPI version| |Conda version| |Documentation Status| |ci| |codecov| |standard-readme compliant| |MIT-image| |reuse| |black| |pre-commit.ci| |joss| |discord| |stackoverflow|
 
-Atlite is a `free software`_, `xarray`_-based Python library for
+atlite is a `free software`_, `xarray`_-based Python library for
 converting weather data (like wind speeds, solar influx) into energy systems data.
 It is designed to be lightweight, keeping computing resource requirements (CPU, RAM) usage low.
 It is therefore well suited to be used with big weather datasets.
 
-.. Atlite is designed to be modular, so that it can work with any weather
+.. atlite is designed to be modular, so that it can work with any weather
 .. datasets. It currently has modules for the following datasets:
 
 .. * `NCEP Climate Forecast System <http://rda.ucar.edu/datasets/ds094.1/>`_ hourly
@@ -31,7 +31,7 @@ It is therefore well suited to be used with big weather datasets.
 ..   combined with ERA5 temperature).
 
 
-Atlite can process the following weather data fields and can convert them into following power-system relevant time series for any subsets of a full weather database.
+atlite can process the following weather data fields and can convert them into following power-system relevant time series for any subsets of a full weather database.
 
 .. image:: doc/workflow_chart.png
 
@@ -53,7 +53,7 @@ Atlite can process the following weather data fields and can convert them into f
 .. * Heating demand (based on the degree-day approximation)
 
 
-Atlite was initially developed by the `Renewable Energy Group
+atlite was initially developed by the `Renewable Energy Group
 <https://fias.uni-frankfurt.de/physics/schramm/renewable-energy-system-and-network-analysis/>`_
 at `FIAS <https://fias.uni-frankfurt.de/>`_ to carry out simulations
 for the `CoNDyNet project <http://condynet.de/>`_, financed by the
@@ -120,7 +120,7 @@ Support & Contributing
 Authors and Copyright
 ---------------------
 
-Copyright (C) 2016 - 2024 Contributors to Atlite <https://github.com/pypsa/atlite>
+Copyright (C) 2016 - 2024 Contributors to atlite <https://github.com/pypsa/atlite>
 
 See the `AUTHORS`_ for details.
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -126,7 +126,7 @@ Version 0.2.8
 * Bugfix: When only adding geometries to an `atlite.ExclusionContainer` the geometries were previously
   not opened and an error was thrown. The error did not occur if one or more shapes were included.
   Error is corrected and geometry-only exclusions can now be calculated. (GH Issue #225)
-* Atlite now includes the reference turbines from the NREL turbine archive (see: https://nrel.github.io/turbine-models/). Available turbines can be consulted using `atlite.windturbines` and can be passed as string argument, e.g. `coutout.wind(turbine)`.
+* atlite now includes the reference turbines from the NREL turbine archive (see: https://nrel.github.io/turbine-models/). Available turbines can be consulted using `atlite.windturbines` and can be passed as string argument, e.g. `coutout.wind(turbine)`.
 * Bugfix: Downsampling the availability matrix (high resolution to low resolution) failed. Only rasters with 0 or 1
   were produced. Expected are also floats between 0 and 1 (GH Issue #238). Changing the rasterio version solved this.
   See solution (https://github.com/PyPSA/atlite/pull/240).
@@ -143,16 +143,16 @@ Version 0.2.7
 Version 0.2.6
 ==============
 
-* Atlite now supports calculating dynamic line ratings based on the IEEE-738 standard (https://github.com/PyPSA/atlite/pull/189).
+* atlite now supports calculating dynamic line ratings based on the IEEE-738 standard (https://github.com/PyPSA/atlite/pull/189).
 * The wind feature provided by ERA5 now also calculates the wind angle `wnd_azimuth` in range [0 - 2π) spanning the cirlce from north in clock-wise direction (0 is north, π/2 is east, -π is south, 3π/2 is west).
 * A new intersection matrix function was added, which works similarly to incidence matrix but has boolean values.
-* Atlite now supports two CSP (concentrated solar power) technologies, solar tower and parabolic trough. See (https://atlite.readthedocs.io/en/latest/examples/working-with-csp.html) for details.
+* atlite now supports two CSP (concentrated solar power) technologies, solar tower and parabolic trough. See (https://atlite.readthedocs.io/en/latest/examples/working-with-csp.html) for details.
 * The solar position (azimuth and altitude) are now part of the cutout feature `influx`. Cutouts created with earlier versions will become incompatible with the next major.
 * Automated upload of code coverage reports via Codecov.
 * DataArrays returned by `.pv(...)` and `.wind(...)` now have a clearer name and 'units' attribute.
 * If the `matrix` argument in conversion functions (`.pv(...)`, `.wind(...)` etc.) is a `DataArray`, the alignment of the coordinate axis with the cutout grid is double-checked.
 * Due to ambiguity, conversion functions (`.pv(...)`, `.wind(...)` etc.) now raise an `ValueError` if shapes and matrix are given.
-* Atlite now supports calculating of heat pump coefficients of performance (https://github.com/PyPSA/atlite/pull/145).
+* atlite now supports calculating of heat pump coefficients of performance (https://github.com/PyPSA/atlite/pull/145).
 * Enabled the GitHub feature "Cite this repository" to generate a BibTeX file (Added a `CITATION.cff` file to the repository).
 
 **Bug fixes**
@@ -214,8 +214,8 @@ Version 0.2
 **Major changes**
 
 
-* Atlite now **requires Python 3.6 or higher**.
-* We changed the Atlite backend for storing cutout data.
+* atlite now **requires Python 3.6 or higher**.
+* We changed the atlite backend for storing cutout data.
   Existing cutouts either need to be migrated with the
   appropriate functions or (what we recommended) recreated.
 * The backend change also includes some changes to the API.
@@ -242,7 +242,7 @@ Version 0.2
   `Open Energy Database <https://openenergy-platform.org/dataedit/view/supply/turbine_library>`_
   using the string prefix `"oedb:"` when specifying a turbine,
   e.g. `"oedb:Enercon_E-141/4200"`.
-* Atlite now has and uses a new configuration system.
+* atlite now has and uses a new configuration system.
   See the new section on `configuration <https://atlite.readthedocs.io/en/latest/configuration.html>`_
   for details.
 * It is possible to merge two cutouts together, using `Cutout.merge`

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/__init__.py
+++ b/atlite/__init__.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
-Atlite helps you to convert weather data into energy systems model data.
+atlite helps you to convert weather data into energy systems model data.
 
-Atlite is a free software, xarray-based Python library for converting
+atlite is a free software, xarray-based Python library for converting
 weather data (like wind speeds) into energy systems data. It is designed
 to by lightweight and work with big weather datasets while keeping the
 resource requirements especially on CPU and RAM resources low.
@@ -20,7 +20,7 @@ __author__ = (
     "David Schlachtberger (FIAS), "
 )
 
-__copyright__ = "Copyright 2016 - 2024 Contributors to Atlite"
+__copyright__ = "Copyright 2016 - 2024 Contributors to atlite"
 
 import re
 from importlib.metadata import version

--- a/atlite/__init__.py
+++ b/atlite/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
@@ -11,7 +11,7 @@ resource requirements especially on CPU and RAM resources low.
 """
 
 __author__ = (
-    "The Atlite Authors: Gorm Andresen (Aarhus University), "
+    "Gorm Andresen (Aarhus University), "
     "Jonas Hoersch (FIAS/KIT/RLI), "
     "Johannes Hampp (JLUG),"
     "Fabian Hofmann (FIAS)"
@@ -20,7 +20,7 @@ __author__ = (
     "David Schlachtberger (FIAS), "
 )
 
-__copyright__ = "Copyright 2016 - 2021 The Atlite Authors"
+__copyright__ = "Copyright 2016 - 2024 Contributors to Atlite"
 
 import re
 from importlib.metadata import version

--- a/atlite/__init__.py
+++ b/atlite/__init__.py
@@ -11,7 +11,7 @@ resource requirements especially on CPU and RAM resources low.
 """
 
 __author__ = (
-    "Gorm Andresen (Aarhus University), "
+    "Gorm Andresen, "
     "Jonas Hoersch (FIAS/KIT/RLI), "
     "Johannes Hampp (JLUG),"
     "Fabian Hofmann (FIAS)"
@@ -20,7 +20,7 @@ __author__ = (
     "David Schlachtberger (FIAS), "
 )
 
-__copyright__ = "Copyright 2016 - 2024 Contributors to atlite"
+__copyright__ = "Copyright Contributors to atlite"
 
 import re
 from importlib.metadata import version

--- a/atlite/aggregate.py
+++ b/atlite/aggregate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/aggregate.py
+++ b/atlite/aggregate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/csp.py
+++ b/atlite/csp.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/csp.py
+++ b/atlite/csp.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/cutout.py
+++ b/atlite/cutout.py
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
-Base class for Atlite.
+Base class for atlite.
 """
 
 # There is a binary incompatibility between the pip wheels of netCDF4 and
@@ -68,7 +68,7 @@ class Cutout:
 
     def __init__(self, path, **cutoutparams):
         """
-        Provide an Atlite cutout object.
+        Provide an atlite cutout object.
 
         Create a cutout object to use atlite operations on it. Based on the
         provided parameters, atlite first checks whether this cutout already

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/__init__.py
+++ b/atlite/datasets/__init__.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 
 """
-Atlite datasets.
+atlite datasets.
 """
 
 from atlite.datasets import era5, gebco, sarah

--- a/atlite/datasets/__init__.py
+++ b/atlite/datasets/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/datasets/cordex.py
+++ b/atlite/datasets/cordex.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
@@ -8,7 +8,7 @@ dataset.
 DEPRECATED
 ----------
 
-The cordex dataset module has not been ported to Atlite v0.2, yet. Use Atlite v0.0.2 to use it,
+The cordex dataset module has not been ported to atlite v0.2, yet. Use atlite v0.0.2 to use it,
 for the time being!
 """
 

--- a/atlite/datasets/cordex.py
+++ b/atlite/datasets/cordex.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/gebco.py
+++ b/atlite/datasets/gebco.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/gebco.py
+++ b/atlite/datasets/gebco.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2020 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/ncep.py
+++ b/atlite/datasets/ncep.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
@@ -8,7 +8,7 @@ dataset.
 DEPRECATED
 ----------
 
-The ncep dataset module has not been ported to Atlite v0.2, yet. Use Atlite v0.0.2 to use it,
+The ncep dataset module has not been ported to atlite v0.2, yet. Use atlite v0.0.2 to use it,
 for the time being!
 """
 

--- a/atlite/datasets/ncep.py
+++ b/atlite/datasets/ncep.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/datasets/sarah.py
+++ b/atlite/datasets/sarah.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
-Module involving hydro operations in Atlite.
+Module involving hydro operations in atlite.
 """
 
 import logging

--- a/atlite/hydro.py
+++ b/atlite/hydro.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/pv/__init__.py
+++ b/atlite/pv/__init__.py
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """
-Atlite pv module.
+atlite pv module.
 """

--- a/atlite/pv/__init__.py
+++ b/atlite/pv/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/pv/irradiation.py
+++ b/atlite/pv/irradiation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/irradiation.py
+++ b/atlite/pv/irradiation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/orientation.py
+++ b/atlite/pv/orientation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/solar_panel_model.py
+++ b/atlite/pv/solar_panel_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/resources/cspinstallation/SAM_parabolic_trough.yaml
+++ b/atlite/resources/cspinstallation/SAM_parabolic_trough.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/cspinstallation/SAM_parabolic_trough.yaml
+++ b/atlite/resources/cspinstallation/SAM_parabolic_trough.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/cspinstallation/SAM_solar_tower.yaml
+++ b/atlite/resources/cspinstallation/SAM_solar_tower.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/cspinstallation/SAM_solar_tower.yaml
+++ b/atlite/resources/cspinstallation/SAM_solar_tower.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/cspinstallation/lossless_installation.yaml
+++ b/atlite/resources/cspinstallation/lossless_installation.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/cspinstallation/lossless_installation.yaml
+++ b/atlite/resources/cspinstallation/lossless_installation.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/solarpanel/CSi.yaml
+++ b/atlite/resources/solarpanel/CSi.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/solarpanel/CSi.yaml
+++ b/atlite/resources/solarpanel/CSi.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/solarpanel/CdTe.yaml
+++ b/atlite/resources/solarpanel/CdTe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/solarpanel/CdTe.yaml
+++ b/atlite/resources/solarpanel/CdTe.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/solarpanel/KANENA.yaml
+++ b/atlite/resources/solarpanel/KANENA.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/solarpanel/KANENA.yaml
+++ b/atlite/resources/solarpanel/KANENA.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Bonus_B1000_1000kW.yaml
+++ b/atlite/resources/windturbine/Bonus_B1000_1000kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Bonus_B1000_1000kW.yaml
+++ b/atlite/resources/windturbine/Bonus_B1000_1000kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Enercon_E101_3000kW.yaml
+++ b/atlite/resources/windturbine/Enercon_E101_3000kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Enercon_E101_3000kW.yaml
+++ b/atlite/resources/windturbine/Enercon_E101_3000kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Enercon_E126_7500kW.yaml
+++ b/atlite/resources/windturbine/Enercon_E126_7500kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Enercon_E126_7500kW.yaml
+++ b/atlite/resources/windturbine/Enercon_E126_7500kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Enercon_E82_3000kW.yaml
+++ b/atlite/resources/windturbine/Enercon_E82_3000kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Enercon_E82_3000kW.yaml
+++ b/atlite/resources/windturbine/Enercon_E82_3000kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_10MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_10MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_10MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_10MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_6MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_6MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_6MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_6MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_8MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_8MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_8MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2016CACost_8MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_12MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_12MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_12MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_12MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_15MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_15MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_15MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2019ORCost_15MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_12MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_12MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_12MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_12MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_15MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_15MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_15MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_15MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_18MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_18MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_18MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_18MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_4MW.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_4MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_4MW.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_4MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_5.5MW.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_5.5MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_5.5MW.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_5.5MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_7MW.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_7MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_7MW.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_2020ATB_7MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_5MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_5MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/NREL_ReferenceTurbine_5MW_offshore.yaml
+++ b/atlite/resources/windturbine/NREL_ReferenceTurbine_5MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Siemens_SWT_107_3600kW.yaml
+++ b/atlite/resources/windturbine/Siemens_SWT_107_3600kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Siemens_SWT_107_3600kW.yaml
+++ b/atlite/resources/windturbine/Siemens_SWT_107_3600kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Siemens_SWT_2300kW.yaml
+++ b/atlite/resources/windturbine/Siemens_SWT_2300kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Siemens_SWT_2300kW.yaml
+++ b/atlite/resources/windturbine/Siemens_SWT_2300kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Suzlon_S82_1.5_MW.yaml
+++ b/atlite/resources/windturbine/Suzlon_S82_1.5_MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Suzlon_S82_1.5_MW.yaml
+++ b/atlite/resources/windturbine/Suzlon_S82_1.5_MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V112_3MW.yaml
+++ b/atlite/resources/windturbine/Vestas_V112_3MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V112_3MW.yaml
+++ b/atlite/resources/windturbine/Vestas_V112_3MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V112_3MW_offshore.yaml
+++ b/atlite/resources/windturbine/Vestas_V112_3MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V112_3MW_offshore.yaml
+++ b/atlite/resources/windturbine/Vestas_V112_3MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V164_7MW_offshore.yaml
+++ b/atlite/resources/windturbine/Vestas_V164_7MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V164_7MW_offshore.yaml
+++ b/atlite/resources/windturbine/Vestas_V164_7MW_offshore.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V25_200kW.yaml
+++ b/atlite/resources/windturbine/Vestas_V25_200kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V25_200kW.yaml
+++ b/atlite/resources/windturbine/Vestas_V25_200kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V47_660kW.yaml
+++ b/atlite/resources/windturbine/Vestas_V47_660kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V47_660kW.yaml
+++ b/atlite/resources/windturbine/Vestas_V47_660kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V66_1750kW.yaml
+++ b/atlite/resources/windturbine/Vestas_V66_1750kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V66_1750kW.yaml
+++ b/atlite/resources/windturbine/Vestas_V66_1750kW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V80_2MW_gridstreamer.yaml
+++ b/atlite/resources/windturbine/Vestas_V80_2MW_gridstreamer.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V80_2MW_gridstreamer.yaml
+++ b/atlite/resources/windturbine/Vestas_V80_2MW_gridstreamer.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V90_3MW.yaml
+++ b/atlite/resources/windturbine/Vestas_V90_3MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/resources/windturbine/Vestas_V90_3MW.yaml
+++ b/atlite/resources/windturbine/Vestas_V90_3MW.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: CC-BY-4.0
 

--- a/atlite/utils.py
+++ b/atlite/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/utils.py
+++ b/atlite/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 comment: false

--- a/doc/chart.py
+++ b/doc/chart.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/doc/chart.py
+++ b/doc/chart.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,7 @@ master_doc = "index"
 # General information about the project.
 project = "atlite"
 author = "Contributors to atlite"
-copyright = "2016 - 2024" + ", " + author
+copyright = author
 documentation_title = "atlite Documentation"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 
 #
-# Atlite documentation build configuration file, created by
+# atlite documentation build configuration file, created by
 # sphinx-quickstart on Tue Jan 5 10:04:42 2016.
 #
 # This file is execfile()d with the current directory set to its
@@ -65,9 +65,9 @@ master_doc = "index"
 
 # General information about the project.
 project = "atlite"
-author = "Contributors to Atlite"
+author = "Contributors to atlite"
 copyright = "2016 - 2024" + ", " + author
-documentation_title = "Atlite Documentation"
+documentation_title = "atlite Documentation"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2017 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 
@@ -65,8 +65,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "atlite"
-author = "The Atlite Authors"
-copyright = "2016-2023" + ", " + author
+author = "Contributors to Atlite"
+copyright = "2016 - 2024" + ", " + author
 documentation_title = "Atlite Documentation"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -7,7 +7,7 @@
 Conventions
 ############
 
-Atlite uses the following conventions which are applied for processing geo-spatial and temporal data.
+atlite uses the following conventions which are applied for processing geo-spatial and temporal data.
 
 Grid coordinates
 ================

--- a/doc/conventions.rst
+++ b/doc/conventions.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/examples/more_examples.rst
+++ b/doc/examples/more_examples.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -8,7 +8,7 @@ More Examples
 #############
 
 All examples are available as Jupyter notebooks in our
-`Atlite GitHub repository <https://github.com/PyPSA/atlite/tree/master/examples>`_.
+`atlite GitHub repository <https://github.com/PyPSA/atlite/tree/master/examples>`_.
 
 
 If you are missing an example for a certain

--- a/doc/examples/more_examples.rst
+++ b/doc/examples/more_examples.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -14,8 +14,8 @@ Atlite: Convert weather data to energy systems data
     :target: https://anaconda.org/conda-forge/atlite
     :alt: Conda version
 
-.. image:: https://github.com/PyPSA/atlite/actions/workflows/CI.yaml/badge.svg
-   :target: https://github.com/PyPSA/atlite/actions/workflows/CI.yaml
+.. image:: https://github.com/PyPSA/atlite/actions/workflows/test.yaml/badge.svg
+   :target: https://github.com/PyPSA/atlite/actions/workflows/test.yaml
 
 .. image:: https://codecov.io/gh/PyPSA/atlite/branch/master/graph/badge.svg?token=TEJ16CMIHJ
    :target: https://codecov.io/gh/PyPSA/atlite

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,9 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
-Atlite: Convert weather data to energy systems data
+atlite: Convert weather data to energy systems data
 ===================================================
 
 .. image:: https://img.shields.io/pypi/v/atlite.svg
@@ -40,7 +40,7 @@ Atlite: Convert weather data to energy systems data
    :target: https://stackoverflow.com/questions/tagged/pypsa
    :alt: Stackoverflow
 
-Atlite is a `free software
+atlite is a `free software
 <http://www.gnu.org/philosophy/free-sw.en.html>`_, `xarray
 <http://xarray.pydata.org/en/stable/>`_-based Python library for
 converting weather data (such as wind speeds, solar radiation,
@@ -55,17 +55,17 @@ E.g. using our recommended dataset `ERA5 <https://www.ecmwf.int/en/forecasts/dat
 we can obtain time-series with hourly resolution on a 30 km x 30 km
 grid.
 
-The time series derived with Atlite are used in energy system models
+The time series derived with atlite are used in energy system models
 like e.g. `PyPSA-EUR <https://github.com/PyPSA/pypsa-eur>`_
 or projects like `model.energy <https://model.energy/>`_.
 
 Maintainers
 ===========
 
-Atlite is currently maintained by volunteers from different institutions
+atlite is currently maintained by volunteers from different institutions
 with no dedicated funding for developing this package.
 
-Atlite was initially developed by the `Renewable Energy Group
+atlite was initially developed by the `Renewable Energy Group
 <https://fias.uni-frankfurt.de/physics/schramm/renewable-energy-system-and-network-analysis/>`_
 at `FIAS <https://fias.uni-frankfurt.de/>`_ to carry out simulations
 for the `CoNDyNet project <http://condynet.de/>`_, financed by the
@@ -77,17 +77,17 @@ Research Initiative
 Origin
 ======
 
-Atlite was originally conceived as a light-weight version of the Aarhus
+atlite was originally conceived as a light-weight version of the Aarhus
 University RE Atlas (`original publication doi:10.1016/j.energy.2015.09.071 <http://dx.doi.org/10.1016/j.energy.2015.09.071>`_).
 It has since been extended to use weather datasets simulated with projected
 climate change and to compute other time series, such as hydro power,
 solar thermal collectors and heating demand.
 
 
-Citing Atlite
+Citing atlite
 =============
 
-If you would like to cite the Atlite software, please refer to `this paper <https://doi.org/10.21105/joss.03294>`_ published in `JOSS <https://joss.theoj.org/>`_.
+If you would like to cite the atlite software, please refer to `this paper <https://doi.org/10.21105/joss.03294>`_ published in `JOSS <https://joss.theoj.org/>`_.
 
 
 
@@ -134,5 +134,5 @@ If you would like to cite the Atlite software, please refer to `this paper <http
 License
 =======
 
-Atlite is released and licensed under the
+atlite is released and licensed under the
 `MIT license <https://github.com/PyPSA/atlite/blob/mit-license/LICENSES/MIT.txt>`_.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -12,13 +12,13 @@ Getting Python
 ==============
 
 If it is your first time with Python, we recommend `conda
-<https://docs.conda.io/en/latest/miniconda.html>`_, `mamba
-<https://github.com/mamba-org/mamba>`_ or `pip
+<https://docs.conda.io/en/latest/miniconda.html>`_ or `pip
 <https://pip.pypa.io/en/stable/>`_ as easy-to-use package managers. They are
 available for Windows, Mac OS X and GNU/Linux.
 
-It is always helpful to use dedicated `conda/mamba environments <https://mamba.readthedocs.io/en/latest/user_guide/mamba.html>`_ or `virtual environments
-<https://pypi.python.org/pypi/virtualenv>`_.
+It is always helpful to use dedicated `conda environments 
+<https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_ 
+or `virtual environments <https://pypi.python.org/pypi/virtualenv>`_.
 
 
 Installation with conda
@@ -27,8 +27,6 @@ Installation with conda
 If you are using ``conda`` you can install PyPSA with::
 
     conda install -c conda-forge atlite
-
-Replace ``conda`` with ``mamba`` if you use this alternative.
 
 
 Installing with pip

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,65 +1,50 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
-############
+##############
 Installation
-############
+##############
 
-There are three possibilities to install atlite:
 
-* conda::
+Getting Python
+==============
+
+If it is your first time with Python, we recommend `conda
+<https://docs.conda.io/en/latest/miniconda.html>`_, `mamba
+<https://github.com/mamba-org/mamba>`_ or `pip
+<https://pip.pypa.io/en/stable/>`_ as easy-to-use package managers. They are
+available for Windows, Mac OS X and GNU/Linux.
+
+It is always helpful to use dedicated `conda/mamba environments <https://mamba.readthedocs.io/en/latest/user_guide/mamba.html>`_ or `virtual environments
+<https://pypi.python.org/pypi/virtualenv>`_.
+
+
+Installation with conda
+=======================
+
+If you are using ``conda`` you can install PyPSA with::
 
     conda install -c conda-forge atlite
 
+Replace ``conda`` with ``mamba`` if you use this alternative.
 
-* pypi::
+
+Installing with pip
+===================
+
+If you have the Python package installer ``pip`` then just run::
 
     pip install atlite
 
-* or directly from GitHub for the most recent version::
+If you're feeling adventurous, you can also install the latest master branch from github with::
 
-    pip install git+https://github.com/pypsa/atlite/
-
-Requirements
-============
-
-Conda environment
------------------
-
-We provide a `conda environment file <https://github.com/PyPSA/atlite/blob/master/environment.yaml>`_
-for conveniently setting up all required and optional packages.
-For information on setting up conda environments from file,
-`click here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file>`_.
-
-Python version
---------------
-
-With the new version 0.2, Atlite requires an installed version of
-**Python 3.6 or above**.
-
-Required packages
------------------
-
-* bottleneck
-* cdsapi
-* dask (0.18.0+)
-* geopandas
-* netcdf4
-* numexpr
-* numpy
-* pandas
-* progressbar2
-* rasterio
-* rtree
-* scipy
-* shapely
-* xarray (0.11.2+)
+    pip install git+https://github.com/PyPSA/atlite.git
 
 
 Computational resources
------------------------
+=======================
 
 As for requirements on your computing equipment, we tried to keep
 the resource requirements low.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -56,9 +56,9 @@ and can run in the background without clogging our computers.
 
 With regards to
 
-* CPU: While Atlite does some number crunching, it does not require
+* CPU: While atlite does some number crunching, it does not require
   special or large multicore CPUs
-* Memory: For the ERA5 dataset you should be fine running Atlite with
+* Memory: For the ERA5 dataset you should be fine running atlite with
   even 2-4 GiB.
   Other datasets can require more memory, as they sometimes need to be
   loaded fully or partially into memory for creating a cutout.

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -8,7 +8,7 @@ Introduction
 ############
 
 
-Atlite processes weather data and converts it into energy system
+atlite processes weather data and converts it into energy system
 relevant quantities, mainly you can create data for
 
 
@@ -31,7 +31,7 @@ Starting from a global weather dataset, *e.g.* our standard data source ECMWF's 
     :alt: alternate text
 
 
-Atlite enables you to create a **cutout**, a spatial and
+atlite enables you to create a **cutout**, a spatial and
 temporal subset of the original data which includes all relevant data
 such as wind velocity, influx, temperature etc.
 
@@ -52,14 +52,14 @@ From there, you can extract various quantities and general properties of the dat
 
 for a specific turbine type (this gives you information on the share of capacity which is in average running and producing power).
 
-Further, you can set power plants to specific spots and let Atlite calculate their actual power production. The **capacity layout**  specifies which grid cell contains what amount of capacity of *one* production type. Atlite comes along with a small `library of wind turbine configurations and PV panel configurations <https://github.com/PyPSA/atlite/tree/master/atlite/resources>`_  which you can directly use, *e.g.* 'Vestas_V112_3MW' wind turbines.
+Further, you can set power plants to specific spots and let atlite calculate their actual power production. The **capacity layout**  specifies which grid cell contains what amount of capacity of *one* production type. atlite comes along with a small `library of wind turbine configurations and PV panel configurations <https://github.com/PyPSA/atlite/tree/master/atlite/resources>`_  which you can directly use, *e.g.* 'Vestas_V112_3MW' wind turbines.
 
 .. image:: img/layout.png
     :width: 400pt
     :align: center
     :alt: alternate text
 
-Atlite then calculates the power generation data for each cell and either aggregates them to buses
+atlite then calculates the power generation data for each cell and either aggregates them to buses
 
 .. image:: img/produced_power.png
     :width: 400pt
@@ -73,7 +73,7 @@ or to geometrical shapes
     :align: center
 
 
-Whereas for the first case, grid cells must directly be assigned to buses by passing a matrix of size :math:`N_{cell} \times N_{bus}`, for the second case, the aggregation to shapes takes place in Atlite itself: It creates the mentioned matrix, the so-called **indicator matrix**, which contains the spatial overlap of each grid cell (weighted by the capacity layout if present) with each shape. This is why the shapes can the very refined and even smaller than the grid cells. In our example the **indicator matrix** for the shape of United Kingdom without being weighted by the **capacity layout** looks like this
+Whereas for the first case, grid cells must directly be assigned to buses by passing a matrix of size :math:`N_{cell} \times N_{bus}`, for the second case, the aggregation to shapes takes place in atlite itself: It creates the mentioned matrix, the so-called **indicator matrix**, which contains the spatial overlap of each grid cell (weighted by the capacity layout if present) with each shape. This is why the shapes can the very refined and even smaller than the grid cells. In our example the **indicator matrix** for the shape of United Kingdom without being weighted by the **capacity layout** looks like this
 
 
 .. image:: img/indicator_matrix.png
@@ -114,11 +114,11 @@ file an issue on our `GitHub <https://github.com/PyPSA/atlite>`_ or (even better
 
 
 
-What Atlite does not cover (yet)
+What atlite does not cover (yet)
 =================================
 
-* Atlite does not provide and **graphical user interface** (GUI) and relies on prior knowledge on working with Python commands.
+* atlite does not provide and **graphical user interface** (GUI) and relies on prior knowledge on working with Python commands.
 
-* Atlite does not provide **exact prediction** of the time-series generation at high resolution in a **future point** in time. The spatial resolution of the  results is limited by the input data used. The accuracy of the results is in parts limited by the methodologies used for translating weather data into generation and the underlying assumptions. With the current assumptions Atlite is not suited for predicting the output of single wind turbines or solar panels.
+* atlite does not provide **exact prediction** of the time-series generation at high resolution in a **future point** in time. The spatial resolution of the  results is limited by the input data used. The accuracy of the results is in parts limited by the methodologies used for translating weather data into generation and the underlying assumptions. With the current assumptions atlite is not suited for predicting the output of single wind turbines or solar panels.
 
-* As the results of Atlite are theoretical and are not validated per se, and while usually a good approximation, can **deviate significantly from reality**. While in the past and also at the moment datasets generate by packages similar to Atlite where commonly used without a comparison and validation with reality, there is currently a trend to validate the datasets before using them to make sure that results are at least plausible. The Atlite team is planning to include auxiliary functions which help to validate generated datasets.
+* As the results of atlite are theoretical and are not validated per se, and while usually a good approximation, can **deviate significantly from reality**. While in the past and also at the moment datasets generate by packages similar to atlite where commonly used without a comparison and validation with reality, there is currently a trend to validate the datasets before using them to make sure that results are at least plausible. The atlite team is planning to include auxiliary functions which help to validate generated datasets.

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -90,7 +90,7 @@ The standard data source we currently employ is ECMWF's ERA5 dataset
 This dataset is easily available at no additional costs and requires only
 minimal setup from the user in comparison to other datasets.
 It is downloaded automatically on-demand after the
-`ECMWF ADS API <https://cds.climate.copernicus.eu/api-how-to>`_
+`ECMWF ADS API <https://cds.climate.copernicus.eu/how-to-api>`_
 (European Centre for Medium-Range Weather Forecasts Climate Data Store
 Application Program Interface) client is properly installed. See separate,
 linked installation guide for details, especially for correctly setting up

--- a/doc/license.rst
+++ b/doc/license.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/license.rst
+++ b/doc/license.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 
@@ -7,7 +7,7 @@
 License
 #######
 
-Atlite is released and licensed under the
+atlite is released and licensed under the
 `MIT license <https://github.com/PyPSA/atlite/blob/mit-license/LICENSES/MIT.txt>`_.
 
 Some configuration and data files are released under

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,4 +1,4 @@
-REM SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+REM SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 REM SPDX-License-Identifier: MIT
 
 @ECHO OFF

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,4 +1,4 @@
-REM SPDX-FileCopyrightText: 2017 - 2023 The Atlite Authors
+REM SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 REM SPDX-License-Identifier: MIT
 
 @ECHO OFF

--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/ref_api.rst
+++ b/doc/ref_api.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: 2016 - 2023 The Atlite Authors
+  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
   SPDX-License-Identifier: CC-BY-4.0
 

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -1,6 +1,6 @@
 
 ..
-  SPDX-FileCopyrightText: 2019 - 2024 The PyPSA-Eur Authors
+  SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
   SPDX-License-Identifier: CC-BY-4.0
 
 #######################

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -1,6 +1,6 @@
 
 ..
-  SPDX-FileCopyrightText: 2019-2023 The PyPSA-Eur Authors
+  SPDX-FileCopyrightText: 2019 - 2024 The PyPSA-Eur Authors
   SPDX-License-Identifier: CC-BY-4.0
 
 #######################

--- a/examples/building_stock_weather_aggregation.ipynb.license
+++ b/examples/building_stock_weather_aggregation.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2024 Topi Rasku
+SPDX-FileCopyrightText: Topi Rasku
 
 SPDX-License-Identifier: MIT

--- a/examples/building_stock_weather_aggregation.ipynb.license
+++ b/examples/building_stock_weather_aggregation.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 Topi Rasku
+SPDX-FileCopyrightText: 2021 - 2024 Topi Rasku
 
 SPDX-License-Identifier: MIT

--- a/examples/create_cutout.ipynb
+++ b/examples/create_cutout.ipynb
@@ -12,7 +12,7 @@
    "metadata": {},
    "source": [
     "In this example we download ERA5 data on-demand for a cutout we want to create.\n",
-    "(Atlite does also work with other datasources, but ERA5 is the easiest one to get started.)\n",
+    "(atlite does also work with other datasources, but ERA5 is the easiest one to get started.)\n",
     "\n",
     "This only works if you have in before\n",
     "\n",

--- a/examples/create_cutout.ipynb.license
+++ b/examples/create_cutout.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/create_cutout.ipynb.license
+++ b/examples/create_cutout.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/create_cutout_SARAH.ipynb.license
+++ b/examples/create_cutout_SARAH.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/create_cutout_SARAH.ipynb.license
+++ b/examples/create_cutout_SARAH.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/historic-comparison-germany.ipynb.license
+++ b/examples/historic-comparison-germany.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/historic-comparison-germany.ipynb.license
+++ b/examples/historic-comparison-germany.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/landuse-availability.ipynb
+++ b/examples/landuse-availability.ipynb
@@ -199,7 +199,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that the weather cells are much larger than the raster cells. `GDAL` provides a fast reprojection function for averaging fine-grained to coarse-grained rasters. `Atlite` automates this calculation for all geometries in `shapes` when calling the `cutout.availabilitymatrix` function. Let's see how this function performs. (Note that the steps before are not necessary for this calculation.)\n",
+    "We see that the weather cells are much larger than the raster cells. `GDAL` provides a fast reprojection function for averaging fine-grained to coarse-grained rasters. `atlite` automates this calculation for all geometries in `shapes` when calling the `cutout.availabilitymatrix` function. Let's see how this function performs. (Note that the steps before are not necessary for this calculation.)\n",
     "\n",
     "**INFO**: *For large sets of shapes set nprocesses to a number > 1 for parallelization.*"
    ]
@@ -335,7 +335,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/examples/landuse-availability.ipynb.license
+++ b/examples/landuse-availability.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/landuse-availability.ipynb.license
+++ b/examples/landuse-availability.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/logfiles_and_messages.ipynb
+++ b/examples/logfiles_and_messages.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Logfiles and messages\n",
     "\n",
-    "Atlite uses the `logging` [library](https://docs.python.org/3/howto/logging.html) for displaying\n",
+    "atlite uses the `logging` [library](https://docs.python.org/3/howto/logging.html) for displaying\n",
     "messages with different purposes."
    ]
   },

--- a/examples/logfiles_and_messages.ipynb.license
+++ b/examples/logfiles_and_messages.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/logfiles_and_messages.ipynb.license
+++ b/examples/logfiles_and_messages.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/plotting_with_atlite.ipynb
+++ b/examples/plotting_with_atlite.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Plotting with Atlite\n",
+    "# Plotting with atlite\n",
     "\n",
-    "This little notebook creates all the plots given in the introduction section. Geographical plotting with Atlite can be efficiently and straightfowardly done when relying on some well maintained python packages. In particular a good rule of thumb is following. When it comes to \n",
+    "This little notebook creates all the plots given in the introduction section. Geographical plotting with atlite can be efficiently and straightfowardly done when relying on some well maintained python packages. In particular a good rule of thumb is following. When it comes to \n",
     "\n",
     "* **projections and transformation** &rightarrow; ask [Cartopy](https://pypi.org/project/Cartopy/)\n",
     "* **plotting shapes** &rightarrow; ask [GeoPandas](http://geopandas.org/)\n",
@@ -349,7 +349,7 @@
     "\n",
     "* use [seaborn heatmap](https://seaborn.pydata.org/generated/seaborn.heatmap.html) for plotting the indicator matrix of the United Kingdom shape\n",
     "\n",
-    "This indicator matrix is used to tell Atlite, which cells in the cutout represent the land area of the UK."
+    "This indicator matrix is used to tell atlite, which cells in the cutout represent the land area of the UK."
    ]
   },
   {

--- a/examples/plotting_with_atlite.ipynb.license
+++ b/examples/plotting_with_atlite.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/plotting_with_atlite.ipynb.license
+++ b/examples/plotting_with_atlite.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/solarpv_tracking_options.ipynb.license
+++ b/examples/solarpv_tracking_options.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/solarpv_tracking_options.ipynb.license
+++ b/examples/solarpv_tracking_options.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2022 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/using_gebco_heightmap.ipynb.license
+++ b/examples/using_gebco_heightmap.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/using_gebco_heightmap.ipynb.license
+++ b/examples/using_gebco_heightmap.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/working-with-csp.ipynb.license
+++ b/examples/working-with-csp.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/examples/working-with-csp.ipynb.license
+++ b/examples/working-with-csp.ipynb.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 - 2023 The Atlite Authors
+SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 
 SPDX-License-Identifier: MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2020 - 2023 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 
@@ -11,7 +11,7 @@ name = "atlite"
 dynamic = ["version"]
 description = "Library for fetching and converting weather data to power systems data"
 readme = "README.rst"
-authors=[{name = "The Atlite Authors", email = "jonas.hoersch@posteo.de"}]
+authors=[{name = "Contributors to Atlite", email = "jonas.hoersch@posteo.de"}]
 license = { file = "LICENSE" }
 classifiers=[
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 
@@ -11,7 +11,7 @@ name = "atlite"
 dynamic = ["version"]
 description = "Library for fetching and converting weather data to power systems data"
 readme = "README.rst"
-authors=[{name = "Contributors to Atlite", email = "jonas.hoersch@posteo.de"}]
+authors=[{name = "Contributors to atlite", email = "jonas.hoersch@posteo.de"}]
 license = { file = "LICENSE" }
 classifiers=[
     "Programming Language :: Python :: 3.9",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2016 - 2024 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 

--- a/test/test_creation.py
+++ b/test/test_creation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_creation.py
+++ b/test/test_creation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 - 2024 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_dynamic_line_rating.py
+++ b/test/test_dynamic_line_rating.py
@@ -1,6 +1,6 @@
 #!/vsr/bin/env python3
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_dynamic_line_rating.py
+++ b/test/test_dynamic_line_rating.py
@@ -1,6 +1,6 @@
 #!/vsr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 - 2024 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 - 2024 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 - 2024 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
+# SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 - 2024 The Atlite Authors
+# SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>
 #
 # SPDX-License-Identifier: MIT
 """


### PR DESCRIPTION
- Updates Installation docs
- Changes Copyright information from
```SPDX-FileCopyrightText: x - x The Atlite Authors```
to 
```SPDX-FileCopyrightText: Contributors to Atlite <https://github.com/pypsa/atlite>```
  - According to [REUSE docs](https://reuse.software/faq/#years-copyright) we don't need to add a year. Since the yearly update is quite often forgotten and therefore not up to date, I would remove it for better maintenence.
  - "Contributers to xx" is also the recommended as Copyright Symbol in the [REUSE docs](https://reuse.software/faq/#copyright-symbol) for such projects 