### PR TITLE
feat(wind): Add power law interpolation method for wind conversion

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -539,7 +539,7 @@ def wind(
         raised if the power curve does not have a cut-out wind speed. The default is
         False.
     interpolation_method : {"logarithmic", "power"}
-        Law to interpolate wind speed to turbine hub height. Refer to 
+        Law to interpolate wind speed to turbine hub height. Refer to
         :py:func:`atlite.wind.extrapolate_wind_speed`.
 
     Note

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -539,8 +539,8 @@ def wind(
         raised if the power curve does not have a cut-out wind speed. The default is
         False.
     interpolation_method : {"logarithmic", "power"}
-        Law to interpolate wind speed to turbine hub height. Refer to docstring of
-        atlite.wind.extrapolate_wind_speed .
+        Law to interpolate wind speed to turbine hub height. Refer to 
+        :py:func:`atlite.wind.extrapolate_wind_speed`.
 
     Note
     ----

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -5,11 +5,14 @@
 All functions for converting weather data into energy system model data.
 """
 
+from __future__ import annotations
+
 import datetime as dt
 import logging
 from collections import namedtuple
 from operator import itemgetter
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import geopandas as gpd
 import numpy as np
@@ -38,6 +41,11 @@ from atlite.resource import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from atlite.resource import TurbineConfig
 
 
 def convert_and_aggregate(
@@ -478,7 +486,11 @@ def solar_thermal(
 
 
 # wind
-def convert_wind(ds, turbine, interpolation_method):
+def convert_wind(
+    ds: xr.Dataset,
+    turbine: TurbineConfig,
+    interpolation_method: Literal["logarithmic", "power"],
+) -> xr.DataArray:
     """
     Convert wind speeds for turbine to wind energy generation.
     """
@@ -507,12 +519,12 @@ def convert_wind(ds, turbine, interpolation_method):
 
 def wind(
     cutout,
-    turbine,
-    smooth=False,
-    add_cutout_windspeed=False,
-    interpolation_method="logarithmic",
+    turbine: str | Path | dict,
+    smooth: bool | dict = False,
+    add_cutout_windspeed: bool = False,
+    interpolation_method: Literal["logarithmic", "power"] = "logarithmic",
     **params,
-):
+) -> xr.DataArray:
     """
     Generate wind generation time-series.
 
@@ -549,14 +561,11 @@ def wind(
 
     References
     ----------
-    [1] Andresen G B, Søndergaard A A and Greiner M 2015 Energy 93, Part 1
-    1074 – 1088. doi:10.1016/j.energy.2015.09.071
+    .. [1] Andresen G B, Søndergaard A A and Greiner M 2015 Energy 93, Part 1
+       1074 – 1088. doi:10.1016/j.energy.2015.09.071
 
     """
-    if isinstance(turbine, (str, Path, dict)):
-        turbine = get_windturbineconfig(
-            turbine, add_cutout_windspeed=add_cutout_windspeed
-        )
+    turbine = get_windturbineconfig(turbine, add_cutout_windspeed=add_cutout_windspeed)
 
     if smooth:
         turbine = windturbine_smooth(turbine, params=smooth)

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -516,8 +516,8 @@ def wind(
     """
     Generate wind generation time-series.
 
-    Extrapolates 10m wind speed with monthly surface roughness to hub
-    height and evaluates the power curve.
+    Extrapolates wind speed to hub height (using logarithmic or power law) and
+    evaluates the power curve.
 
     Parameters
     ----------

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -6,12 +6,15 @@ Module for providing access to external ressources, like windturbine or pv
 panel configurations.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import re
 import warnings
 from operator import itemgetter
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -30,8 +33,24 @@ WINDTURBINE_DIRECTORY = RESOURCE_DIRECTORY / "windturbine"
 SOLARPANEL_DIRECTORY = RESOURCE_DIRECTORY / "solarpanel"
 CSPINSTALLATION_DIRECTORY = RESOURCE_DIRECTORY / "cspinstallation"
 
+if TYPE_CHECKING:
+    from typing import TypedDict
 
-def get_windturbineconfig(turbine, add_cutout_windspeed=False):
+    from typing_extensions import NotRequired
+
+    class TurbineConfig(TypedDict):
+        V: np.ndarray
+        POW: np.ndarray
+        P: float
+        hub_height: float | int
+        name: NotRequired[str]
+        manufacturer: NotRequired[str]
+        source: NotRequired[str]
+
+
+def get_windturbineconfig(
+    turbine: str | Path | dict, add_cutout_windspeed: bool = False
+) -> TurbineConfig:
     """
     Load the wind 'turbine' configuration.
 
@@ -61,7 +80,7 @@ def get_windturbineconfig(turbine, add_cutout_windspeed=False):
         Config with details on the turbine
 
     """
-    assert isinstance(turbine, (str, Path, dict))
+    assert isinstance(turbine, str | Path | dict)
 
     if add_cutout_windspeed is False:
         msg = (
@@ -73,7 +92,7 @@ def get_windturbineconfig(turbine, add_cutout_windspeed=False):
     if isinstance(turbine, str) and turbine.startswith("oedb:"):
         conf = get_oedb_windturbineconfig(turbine[len("oedb:") :])
 
-    elif isinstance(turbine, (str, Path)):
+    elif isinstance(turbine, str | Path):
         if isinstance(turbine, str):
             turbine_path = windturbines[turbine.replace(".yaml", "")]
 
@@ -287,7 +306,9 @@ def _max_v_is_zero_pow(turbine):
     return np.any(turbine["POW"][turbine["V"] == turbine["V"].max()] == 0)
 
 
-def _validate_turbine_config_dict(turbine: dict, add_cutout_windspeed: bool):
+def _validate_turbine_config_dict(
+    turbine: dict, add_cutout_windspeed: bool
+) -> TurbineConfig:
     """
     Checks the turbine config dict format and power curve.
 
@@ -356,7 +377,9 @@ def _validate_turbine_config_dict(turbine: dict, add_cutout_windspeed: bool):
     return turbine
 
 
-def get_oedb_windturbineconfig(search=None, **search_params):
+def get_oedb_windturbineconfig(
+    search: int | str | None = None, **search_params
+) -> TurbineConfig:
     """
     Download a windturbine configuration from the OEDB database.
 

--- a/atlite/wind.py
+++ b/atlite/wind.py
@@ -5,17 +5,28 @@
 Functions for use in conjunction with wind data generation.
 """
 
+from __future__ import annotations
+
 import logging
 import re
+from typing import TYPE_CHECKING
 
 import numpy as np
+import xarray as xr
 
 logger = logging.getLogger(__name__)
 
 
+if TYPE_CHECKING:
+    from typing import Literal
+
+
 def extrapolate_wind_speed(
-    ds, to_height, from_height=None, method: str = "logarithmic"
-):
+    ds: xr.Dataset,
+    to_height: int | float,
+    from_height: int | None = None,
+    method: Literal["logarithmic", "power"] = "logarithmic",
+) -> xr.DataArray:
     """
     Extrapolate the wind speed from a given height above ground to another.
 
@@ -23,7 +34,7 @@ def extrapolate_wind_speed(
     no conversion is done and the wind speeds are directly returned.
 
     Extrapolation of the wind speed can either use the "logarithmic" law as
-    described in [1] or the "power" law as described in [2]. See also discussion
+    described in [1]_ or the "power" law as described in [2]_. See also discussion
     in GH issue: https://github.com/PyPSA/atlite/issues/231 .
 
     Parameters
@@ -32,12 +43,11 @@ def extrapolate_wind_speed(
         Dataset containing the wind speed time-series at 'from_height' with key
         'wnd{height:d}m' and the surface orography with key 'roughness' at the
         geographic locations of the wind speeds.
-    from_height : int
-        (Optional)
-        Height (m) from which the wind speeds are interpolated to 'to_height'.
-        If not provided, the closest height to 'to_height' is selected.
     to_height : int|float
         Height (m) to which the wind speeds are extrapolated to.
+    from_height : int, optional
+        Height (m) from which the wind speeds are interpolated to 'to_height'.
+        If not provided, the closest height to 'to_height' is selected.
     method : {"logarithmic", "power"}
         Method to use for extra/interpolating wind speeds
 
@@ -49,13 +59,13 @@ def extrapolate_wind_speed(
 
     References
     ----------
-    [1] Equation (2) in Andresen, G. et al (2015): 'Validation of Danish wind
-    time series from a new global renewable energy atlas for energy system
-    analysis'.
+    .. [1] Equation (2) in Andresen, G. et al (2015): 'Validation of Danish
+       wind time series from a new global renewable energy atlas for energy
+       system analysis'.
 
-    [2] Gualtieri, G. (2021): 'Reliability of ERA5 Reanalysis Data for Wind
-    Resource Assessment: A Comparison against Tall Towers'
-    https://doi.org/10.3390/en14144169 .
+    .. [2] Gualtieri, G. (2021): 'Reliability of ERA5 Reanalysis Data for
+       Wind Resource Assessment: A Comparison against Tall Towers'
+       https://doi.org/10.3390/en14144169 .
     """
     # Fast lane
     to_name = f"wnd{int(to_height):0d}m"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,24 +28,25 @@ classifiers=[
 ]
 requires-python = ">=3.9"
 dependencies = [
-       "numpy<2.0",
-        "scipy",
-        "pandas>=0.25",
-        "bottleneck",
-        "numexpr",
-        "xarray>=0.20",
-        "netcdf4",
-        "dask>=2021.10.0",
-        "toolz",
-        "requests",
-        "pyyaml",
-        "rasterio",
-        "shapely",
-        "progressbar2",
-        "tqdm",
-        "pyproj>=2",
-        "geopandas",
-        "cdsapi>=0.7.4",
+    "typing-extensions",
+    "numpy<2.0",
+    "scipy",
+    "pandas>=0.25",
+    "bottleneck",
+    "numexpr",
+    "xarray>=0.20",
+    "netcdf4",
+    "dask>=2021.10.0",
+    "toolz",
+    "requests",
+    "pyyaml",
+    "rasterio",
+    "shapely",
+    "progressbar2",
+    "tqdm",
+    "pyproj>=2",
+    "geopandas",
+    "cdsapi>=0.7.4",
 ]
 
 [project.urls]
@@ -58,13 +59,13 @@ Documentation = "https://atlite.readthedocs.io/en/latest/"
 dev = ["pre-commit", "pytest", "pytest-cov", "matplotlib", "ruff"]
 
 docs = [
-            "numpydoc==1.8.0",
-            "sphinx==8.0.2",
-            "sphinx-book-theme==1.1.3",
-            "nbsphinx==0.9.5",
-            "nbsphinx-link==1.3.0",
-            "docutils==0.20",  # Just temporarily until sphinx-docutils is updated (see https://github.com/sphinx-doc/sphinx/issues/12340)
-        ]
+    "numpydoc==1.8.0",
+    "sphinx==8.0.2",
+    "sphinx-book-theme==1.1.3",
+    "nbsphinx==0.9.5",
+    "nbsphinx-link==1.3.0",
+    "docutils==0.20",           # Just temporarily until sphinx-docutils is updated (see https://github.com/sphinx-doc/sphinx/issues/12340)
+]
 
 # Setuptools_scm settings
 

--- a/test/test_preparation_and_conversion.py
+++ b/test/test_preparation_and_conversion.py
@@ -307,6 +307,13 @@ def wind_test(cutout):
     assert production.notnull().all()
     assert production.sum() > 0
 
+    # test with different power law interpolation method
+    production = cutout.wind(
+        atlite.windturbines.Enercon_E101_3000kW,
+        layout=cap_factor,
+        interpolation_method="power",
+    )
+
 
 def runoff_test(cutout):
     """


### PR DESCRIPTION
Closes #231 .

Refer to issue for context. Implements the power law interpolation method as a new argument
to `cutout.wind`. Needs to be chosen manually for now.

A suggested in the issue we retrieve 100m and 10m wind speeds and then calculate a wind shear exponent from those during cutout preparation.

Looks like the power law is preferred at least for turbine heights above wind blending (?) height (70m?). So this should most likely become the new default if we have 100m wind speeds available (as we have for ERA5). 

TODOs:
- [ ] Compare results, maybe following methodology in https://www.mdpi.com/1996-1073/14/14/4169
- [ ] Implement a FutureWarning that the default changes to the power law.
- [ ] Add those interpolation options to the docs.

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
