### PR TITLE
rasterio 1.4.0/1.4.1 flips y-axis in `compute_availabilitymatrix`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,6 +30,9 @@ Upcoming Release
 
 * Added support for ``numpy>=2".
 
+* Exclude versions 1.4.0 and 1.4.1 of ``rasterio`` due to a bug in these
+  versions causing flipped axes in ``cutout.compute_availabilitymatrix()``.
+
 Version 0.3.0
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "toolz",
     "requests",
     "pyyaml",
-    "rasterio",
+    "rasterio!=1.4.0,!=1.4.1",
     "shapely",
     "progressbar2",
     "tqdm",


### PR DESCRIPTION
This is a bit of a random find, but caused some significant faults in renewable potential calculations...

Versions 1.4.0 and 1.4.1 or `rasterio` cause a flipped y-axis in `cutout.compute_availabilitymatrix()`, which neither earlier nor later versions of `rasterio` do. With no changes but changed rasterio version:

## With `rasterio==1.4.{0,1}`

<img src="https://github.com/user-attachments/assets/d35deb7a-5a75-4456-a816-0c35b6b2ff36" width="40%">
 
## With `rasterio<1.4,>=1.4.2`

<img src="https://github.com/user-attachments/assets/3fc1680e-91a4-458f-ba6e-2682c9a7b1c3" width="40%">

I think excluding these versions makes more sense than implementing version-specific behavior in `atlite`.

