### PR TITLE
Fix incorrect unit conversion in hydro function in convert.py

### DIFF
--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -1038,9 +1038,7 @@ def hydro(
     # The hydrological parameters are in units of "m of water per day" and so
     # they should be multiplied by 1000 and the basin area to convert to m3
     # d-1 = m3 h-1 / 24
-    runoff *= xr.DataArray(
-        basins.shapes.to_crs(dict(proj="cea")).area
-    )
+    runoff *= xr.DataArray(basins.shapes.to_crs(dict(proj="cea")).area)
 
     return hydrom.shift_and_aggregate_runoff_for_plants(
         basins, runoff, flowspeed, show_progress

--- a/atlite/convert.py
+++ b/atlite/convert.py
@@ -1038,7 +1038,7 @@ def hydro(
     # The hydrological parameters are in units of "m of water per day" and so
     # they should be multiplied by 1000 and the basin area to convert to m3
     # d-1 = m3 h-1 / 24
-    runoff *= (1000.0 / 24.0) * xr.DataArray(
+    runoff *= xr.DataArray(
         basins.shapes.to_crs(dict(proj="cea")).area
     )
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,3 +5,4 @@
 
 .. include:: ../RELEASE_NOTES.rst
 
+* In ``atlite/convert.py``, the function ``hydro`` is now correctly calculating the runoff in m3 per hour by multiplying the depth (in meters per hour) by the basin area (in m2).


### PR DESCRIPTION
Removed unnecessary factor of 1000/24 from the runoff calculation, as pointed out by user JKALanger. The function now correctly calculates runoff in m3 per hour by directly multiplying the depth (in meters per hour) by the basin area (in square meters).

<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
