### PR TITLE
fix: handle mismatched dim lengths during rechunking (take 2)

### DIFF
--- a/atlite/pv/solar_position.py
+++ b/atlite/pv/solar_position.py
@@ -77,7 +77,7 @@ def SolarPosition(ds, time_shift="0H"):
 
     # Operations make new DataArray eager; reconvert to lazy dask arrays
     chunks = ds.chunksizes.get("time", "auto")
-    if n.ndim == 1:
+    if isinstance(chunks, tuple):
         chunks = chunks[0]
     n = n.chunk(chunks)
     hour = hour.chunk(chunks)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->

Fixes #395 .

@lkstrp
We stumbled over your changes in #395 today starting from some custom code.

If `ds` has an unchunked time dimension you get
```python
chunks = "auto"
```
and then
```python
chunks[0]
```
retrieves the letter "a", which breaks `n.chunk(...)`.

I think you meant to check for whether there are chunks (which are always given as a tuple) and then use the leading chunksize in that case.

@geiges Thanks for the report.


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
