### PR TITLE
Code/download era5 as grib

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -20,6 +20,14 @@ Release Notes
 `v0.4.0 <https://github.com/PyPSA/atlite/releases/tag/v0.4.0>`__ (30th January 2025)
 =======================================================================================
 
+* ERA5 data is now by default using the `grib` backened instead of the `netcdf` backend of the CDS.
+  This change became necessary, as the `netcdf` backend became size-limited, cf. (https://forum.ecmwf.int/t/limitation-change-on-netcdf-era5-requests/12477).
+  Side effects include that downloads of ERA5 data should now be faster and possible for larger extends,
+  with a downside of more processing locally and larger temporary storage requirements.
+  The yielded cutouts should be identical in their data to previous cutouts.
+  You can still use the `netcdf` backend by passing `data_format='netcdf'` to the `cutout.prepare()` method.
+  (https://github.com/PyPSA/atlite/issues/439)
+
 * The methods ``convert_cooling_demand`` and ``cooling_demand`` are implemented
   to evaluate cooling demand using the cooling degree-days approximation.
   (https://github.com/PyPSA/atlite/pull/415, https://github.com/PyPSA/atlite/pull/422)

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -27,6 +27,7 @@ def get_features(
     cutout,
     module,
     features,
+    data_format,
     tmpdir=None,
     monthly_requests=False,
     concurrent_requests=False,
@@ -47,6 +48,7 @@ def get_features(
             cutout,
             feature,
             tmpdir=tmpdir,
+            data_format=data_format,
             lock=lock,
             monthly_requests=monthly_requests,
             concurrent_requests=concurrent_requests,
@@ -125,6 +127,7 @@ def cutout_prepare(
     cutout,
     features=None,
     tmpdir=None,
+    data_format="grib",
     overwrite=False,
     compression={"zlib": True, "complevel": 9, "shuffle": True},
     show_progress=False,
@@ -153,6 +156,8 @@ def cutout_prepare(
         Directory in which temporary files (for example retrieved ERA5 netcdf
         files) are stored. If set, the directory will not be deleted and the
         intermediate files can be examined.
+    data_format : str, optional
+        The data format used to retrieve the data. Only relevant for ERA5 data. The default is 'grib'.
     overwrite : bool, optional
         Whether to overwrite variables which are already included in the
         cutout. The default is False.
@@ -210,6 +215,7 @@ def cutout_prepare(
             module,
             missing_features,
             tmpdir=tmpdir,
+            data_format=data_format,
             monthly_requests=monthly_requests,
             concurrent_requests=concurrent_requests,
         )

--- a/atlite/data.py
+++ b/atlite/data.py
@@ -60,9 +60,15 @@ def get_features(
 
     ds = xr.merge(datasets, compat="equals")
     for v in ds:
-        ds[v].attrs["module"] = module
+        da = ds[v]
+        da.attrs["module"] = module
         fd = datamodules[module].features.items()
-        ds[v].attrs["feature"] = [k for k, l in fd if v in l].pop()
+        da.attrs["feature"] = [k for k, l in fd if v in l].pop()
+
+        if da.chunks is not None:
+            chunksizes = [c[0] for c in da.chunks]
+            da.encoding["chunksizes"] = chunksizes
+
     return ds
 
 

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -20,8 +20,8 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from dask import compute, delayed
-from dask.utils import SerializableLock
 from dask.array import arctan2, sqrt
+from dask.utils import SerializableLock
 from numpy import atleast_1d
 
 from atlite.gis import maybe_swap_spatial_dims
@@ -428,7 +428,13 @@ def _convert_grib_to_netcdf(grib_file: str | Path, netcdf_file: str | Path) -> N
     )
 
 
-def retrieve_data(product: str, chunks: dict[str, int] | None = None, tmpdir: str | Path | None = None, lock: SerializableLock | None = None, **updates) -> xr.Dataset:
+def retrieve_data(
+    product: str,
+    chunks: dict[str, int] | None = None,
+    tmpdir: str | Path | None = None,
+    lock: SerializableLock | None = None,
+    **updates,
+) -> xr.Dataset:
     """
     Download data like ERA5 from the Climate Data Store (CDS).
 
@@ -451,7 +457,7 @@ def retrieve_data(product: str, chunks: dict[str, int] | None = None, tmpdir: st
         Additional parameters for the request.
         Must include 'year', 'month', and 'variable'.
         Can include e.g. 'data_format'.
-    
+
     Returns
     -------
     xarray.Dataset

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -344,9 +344,7 @@ def _convert_grib_to_netcdf(grib_file, netcdf_file):
     logger.debug(f"Converting grib to netCDF file: {grib_file}")
     fname = Path(grib_file).stem
 
-    ### Configuration options for opening the GRIB files as an xarray object,
-    #  these depend on the dataset your are working with, this example is for ERA5 single-levels
-
+    # Open grib file as dataset
     # Options to open different datasets into a datasets of consistent hypercubes which are compatible netCDF
     # There are options that might be relevant for e.g. for wave model data, that have been removed here
     # to keep the code cleaner and shorter
@@ -363,15 +361,12 @@ def _convert_grib_to_netcdf(grib_file, netcdf_file):
         ],
     }
 
-    # Open grib file as dataset
     ds = xr.open_dataset(
         grib_file,
         engine="cfgrib",
         **open_datasets_kwargs,
     )
 
-    # Define a function to safely expand dimensions in an xarray dataset,
-    #  ensures that the data for the new dimensions are in the dataset
     def safely_expand_dims(dataset: xr.Dataset, expand_dims: list[str]) -> xr.Dataset:
         """
         Expand dimensions in an xarray dataset, ensuring that the new dimensions are not already in the dataset
@@ -397,13 +392,13 @@ def _convert_grib_to_netcdf(grib_file, netcdf_file):
         "hybrid": "model_level",
     }
     rename_vars = {k: v for k, v in rename_vars.items() if k in ds}
-
     ds = ds.rename(rename_vars)
 
+    # safely expand dimensions in an xarray dataset to ensure that data for the new dimensions are in the dataset
     ds = safely_expand_dims(ds, ["valid_time", "pressure_level", "model_level"])
 
     logger.debug(f"Writing converted netcdf file: {netcdf_file}")
-    # Compression options to use for each datavar when writing to netcdf
+    # Compression options to use, use a low compression level here for faster writing as the final cutout will be compressed later
     compression_options = {
         "zlib": True,
         "complevel": 1,

--- a/atlite/datasets/era5.py
+++ b/atlite/datasets/era5.py
@@ -88,9 +88,7 @@ def _rename_and_clean_coords(ds, add_lon_lat=True):
     Optionally (add_lon_lat, default:True) preserves latitude and
     longitude columns as 'lat' and 'lon'.
     """
-    ds = ds.rename({"longitude": "x", "latitude": "y"})
-    if "valid_time" in ds.sizes:
-        ds = ds.rename({"valid_time": "time"}).unify_chunks()
+    ds = ds.rename({"longitude": "x", "latitude": "y", "valid_time": "time"})
     # round coords since cds coords are float32 which would lead to mismatches
     ds = ds.assign_coords(
         x=np.round(ds.x.astype(float), 5), y=np.round(ds.y.astype(float), 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pyproj>=2",
     "geopandas",
     "cdsapi>=0.7.4",
+    "cfgrib>=0.9.15.0",
+    "h5netcdf>=1.6.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->

Closes #437 .

## Changes proposed in this Pull Request

As ECMWF has started to limit the request size for requests of netcdf files from CDS for ERA5, this PR suggests code to allow downloading also as grib files, based on the instructions here: https://confluence.ecmwf.int/display/CKB/GRIB+to+netCDF+conversion+on+new+CDS+and+ADS+systems#GRIBtonetCDFconversiononnewCDSandADSsystems-jupiternotebook

This method should be the future default and should yield results identical to the previous downloads, as the conversion from `grib` to `netcdf` should be the same conversion that is done in the CDS through the `cdsapi` automatically (just server-side).

There are some side effects:
* Downloads should be faster
* Local processing becomes necessary, i.e. local storage requirements and processing time might increase
* ECMWF considers `grib` to be more stable than `netcdf` downloads from CDS, i.e. this switch is meaningful in its own rights
* This might also mean that downloads of larger cutouts may no longer require monthly retrieval, to be checked @davide-f .


@lkstrp I'm missing tests, any suggestions which tests to add? Just repurposing of the existing tests maybe?
Local testing of cutouts yields the same results

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
