### PR TITLE
Update geopandas requirement to >=0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "progressbar2",
     "tqdm",
     "pyproj>=2",
-    "geopandas",
+    "geopandas>=0.10.0",
     "cdsapi>=0.7.4",
     "cfgrib>=0.9.15.0",
     "h5netcdf>=1.6.1",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->

Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable). 
- Note: I don't see any of the files. 
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.

Hi. I installed the atlite repository using: `conda install -c conda-forge atlite` and was trying to run the `create_cutout.ipynb`. I faced the issue because geopandas ( version 0.9.0) is still using the deprecated cascaded_union function from shapely.ops. 
![image](https://github.com/user-attachments/assets/15d70aa2-071a-4e80-89df-a1dc18ea40d2)

I checked the changelog for geopandas, and found that there was a fix here for version 0.10.0. See issue 2074. 
https://github.com/geopandas/geopandas/blob/main/CHANGELOG.md#version-0100-october-3-2021. 

I tested this again with pip install with these set of libraries and it seems to prevent this issue. This is my first time contributing to this project, so please let me know if I am doing this correctly! Thanks!