### PR TITLE
Fix reproject_shapes() to avoid flipped coordinats

### DIFF
--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -88,7 +88,7 @@ def reproject_shapes(shapes, crs1, crs2):
     """
     Project a collection of shapes from one crs to another.
     """
-    transformer = Transformer.from_crs(crs1, crs2)
+    transformer = Transformer.from_crs(crs1, crs2, always_xy=True)
 
     def _reproject_shape(shape):
         return transform(transformer.transform, shape)


### PR DESCRIPTION
Fix `reproject_shapes()` to preserve coordinate order by enforcing (x=lon, y=lat) with `always_xy=True` when transforming from one CRS to another

Previously, reprojections involving EPSG:4326 could produce flipped coordinates because pyproj defaults to EPSG axis order (lat, lon). This caused a flipping of the x and y coordinates and subsequently inconsistent results.

The fix explicitly sets always_xy=True in Transformer.from_crs, ensuring that all transformations consistently interpret coordinates as (x=longitude, y=latitude).

<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->

Closes #461 

## Changes proposed in this Pull Request


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
