### PR TITLE
fix raster crs fallback in exclusion container

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -21,7 +21,13 @@ Upcoming Release
 * Add ``aggregate_time={"sum", "mean", None}`` to ``convert_and_aggregate`` for temporal 
   aggregation with and without spatial aggregation, and deprecate ``capacity_factor``/``capacity_factor_timeseries`` 
   in favor of it
-   
+
+**Bug fixes**
+
+* Fix regression when ``ExclusionContainer`` encounters a raster with an invalid CRS
+  (https://github.com/PyPSA/atlite/pull/500).
+
+
 `v0.5.0 <https://github.com/PyPSA/atlite/releases/tag/v0.5.0>`__ (13th March 2026)
 =======================================================================================   
    

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -484,8 +484,8 @@ class ExclusionContainer:
                     raster._crs = CRS(d["crs"])
                 else:
                     raise ValueError(
-                        f"CRS of {raster} must be either geographic or projected, "
-                        "please provide it manually."
+                        f"CRS of {raster} is neither geographic nor projected, "
+                        f"please provide it manually:\n{raster.crs}"
                     )
             d["raster"] = raster
 

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -479,11 +479,14 @@ class ExclusionContainer:
                 assert isinstance(raster, rio.DatasetReader)
 
             # Check if the raster has a valid CRS
-            if not raster.crs:
+            if not (raster.crs.is_geographic or raster.crs.is_projected):
                 if d["crs"]:
                     raster._crs = CRS(d["crs"])
                 else:
-                    raise ValueError(f"CRS of {raster} is invalid, please provide it.")
+                    raise ValueError(
+                        f"CRS of {raster} must be either geographic or projected, "
+                        "please provide it manually."
+                    )
             d["raster"] = raster
 
         for d in self.geometries:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->

## Changes proposed in this Pull Request

Regression that leads to https://github.com/PyPSA/pypsa-eur/issues/2148 after #453 , since the CRS of corine does not contain enough information for reprojecting it:

```python
In [17]: ds = rio.open("../pypsa-eur/data/corine/archive/v18_5/corine.tif")

In [18]: ds.crs
Out[18]: CRS.from_wkt('LOCAL_CS["Geocoding information not available Projection Name = ETRS_1989_LAEA Units = meters GeoTIFF Units = ot",UNIT["unknown",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]')

In [19]: ds.crs.is_valid
<ipython-input-19-fecbbcf2d289>:1: RasterioDeprecationWarning: is_valid is not useful and will be removed in 2.0.0.
  ds.crs.is_valid
Out[19]: False

In [21]: ds.crs.is_projected
Out[21]: False

In [22]: ds.crs.is_geographic
Out[22]: False
```

`is_valid` was just a short form for whether the CRS is either projected or geographic, we still need to check for if either is the case. WGS84 is an example of a geographic crs, epsg 3035 is an example of a projected one (ie a projected has meters and can be used for measuring distances or areas). We need one of the two for projected it to another CRS.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
