### PR TITLE
feat: add circular raster buffer

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -17,6 +17,13 @@ Upcoming Release
    To use the features already you have to install the ``master`` branch, e.g.
    ``pip install git+https://github.com/pypsa/atlite``.
 
+**Features**
+
+* Add ``buffer_geometry`` argument to ``ExclusionContainer.add_raster``. Choose
+  between the historic ``"diamond"`` buffer (default) and a new ``"circular"``
+  buffer that computes a geometrically accurate Euclidean buffer, correct in
+  diagonal directions.
+
 **Bug fixes**
 
 * Fix ``Cutout.line_rating`` passing line azimuth in radians while

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -601,20 +601,20 @@ class ExclusionContainer:
             Use this to create a buffer around the excluded/included area.
             The default is 0.
         buffer_geometry : {"diamond", "circular"}, optional
-            Shape of the buffer kernel applied to raster exclusions:
+            Shape of the buffer applied around raster exclusions. Only used
+            when ``buffer > 0``. The default is ``"diamond"``.
 
-            * ``"diamond"`` (default) – uses :func:`scipy.ndimage.binary_dilation`
-              with the default 4-connected cross structuring element, which
-              produces a diamond (L1-metric) footprint. Equivalent to the
-              historic behaviour.
-            * ``"circular"`` – uses :func:`scipy.ndimage.distance_transform_edt`
-              to compute exact Euclidean distances, giving a true circular
-              (L2-metric) buffer. This is both more geometrically accurate and
-              significantly faster for large buffers because it runs in O(pixels)
-              regardless of buffer size, whereas the diamond approach scales as
-              O(buffer/res × pixels).
-
-            Only used when ``buffer > 0``.
+            * ``"diamond"`` – dilates the mask with
+              :func:`scipy.ndimage.binary_dilation`, expanding it by one pixel
+              in the four cardinal directions per iteration. The footprint is a
+              diamond (L1 metric), so the buffer distance is only accurate along
+              the grid axes and overreaches diagonally. This is the historic
+              behaviour.
+            * ``"circular"`` – marks every pixel whose exact Euclidean distance
+              to the mask (via :func:`scipy.ndimage.distance_transform_edt`) is
+              within ``buffer``, giving a geometrically accurate circular
+              (L2 metric) buffer. Prefer this when diagonal accuracy matters;
+              note that in practice it is typically slower than ``"diamond"``.
         nodata : int, optional
             Value to use for nodata pixels. The default is 255.
         invert : bool, optional

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -27,6 +27,7 @@ from rasterio.mask import mask
 from rasterio.plot import show
 from rasterio.warp import transform_bounds
 from scipy.ndimage import binary_dilation as dilation
+from scipy.ndimage import distance_transform_edt
 from shapely.ops import transform
 from shapely.strtree import STRtree
 from tqdm import tqdm
@@ -462,8 +463,12 @@ def shape_availability(
         if d["invert"]:
             masked_ = ~masked_
         if d["buffer"]:
-            iterations = int(d["buffer"] / excluder.res) + 1
-            masked_ = dilation(masked_, iterations=iterations)
+            if d["buffer_geometry"] == "circular":
+                radius = d["buffer"] / excluder.res
+                masked_ = distance_transform_edt(~masked_) <= radius
+            elif d["buffer_geometry"] == "diamond":
+                iterations = int(d["buffer"] / excluder.res) + 1
+                masked_ = dilation(masked_, iterations=iterations)
 
         exclusions = exclusions | masked_
 
@@ -557,6 +562,7 @@ class ExclusionContainer:
         | Callable[[NDArray], NDArray]
         | None = None,
         buffer: float = 0,
+        buffer_geometry: str = "diamond",
         invert: bool = False,
         nodata: int = 255,
         allow_no_overlap: bool = False,
@@ -579,6 +585,21 @@ class ExclusionContainer:
             Buffer around the excluded areas in units of ExclusionContainer.crs.
             Use this to create a buffer around the excluded/included area.
             The default is 0.
+        buffer_geometry : {"diamond", "circular"}, optional
+            Shape of the buffer kernel applied to raster exclusions:
+
+            * ``"diamond"`` (default) – uses :func:`scipy.ndimage.binary_dilation`
+              with the default 4-connected cross structuring element, which
+              produces a diamond (L1-metric) footprint.  Equivalent to the
+              historic behaviour.
+            * ``"circular"`` – uses :func:`scipy.ndimage.distance_transform_edt`
+              to compute exact Euclidean distances, giving a true circular
+              (L2-metric) buffer.  This is both more geometrically accurate and
+              significantly faster for large buffers because it runs in O(pixels)
+              regardless of buffer size, whereas the diamond approach scales as
+              O(buffer/res × pixels).
+
+            Only used when ``buffer > 0``.
         nodata : int, optional
             Value to use for nodata pixels. The default is 255.
         invert : bool, optional
@@ -596,6 +617,7 @@ class ExclusionContainer:
             "raster": raster,
             "codes": codes,
             "buffer": buffer,
+            "buffer_geometry": buffer_geometry,
             "invert": invert,
             "nodata": nodata,
             "allow_no_overlap": allow_no_overlap,

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -431,6 +431,10 @@ def shape_availability(
     transform : rasterio.Affine
         Affine transform of the mask.
 
+    Raises
+    ------
+    ValueError
+        If an unsupported buffer geometry is encountered.
     """
     if not excluder.all_open:
         excluder.open_files()
@@ -463,12 +467,23 @@ def shape_availability(
         if d["invert"]:
             masked_ = ~masked_
         if d["buffer"]:
-            if d["buffer_geometry"] == "circular":
-                radius = d["buffer"] / excluder.res
-                masked_ = distance_transform_edt(~masked_) <= radius
-            elif d["buffer_geometry"] == "diamond":
+            buffer_geom = d.get("buffer_geometry", "diamond")
+            if buffer_geom == "circular":
+                if masked_.any():
+                    radius = d["buffer"] / excluder.res
+                    masked_ = distance_transform_edt(~masked_) <= radius
+                else:
+                    # If mask is empty, distance_transform_edt treats the boundary
+                    # as background, which would incorrectly exclude border pixels.
+                    pass
+            elif buffer_geom == "diamond":
                 iterations = int(d["buffer"] / excluder.res) + 1
                 masked_ = dilation(masked_, iterations=iterations)
+            else:
+                raise ValueError(
+                    f"Unsupported buffer geometry: '{buffer_geom}'. "
+                    "Must be one of 'diamond' or 'circular'."
+                )
 
         exclusions = exclusions | masked_
 
@@ -590,11 +605,11 @@ class ExclusionContainer:
 
             * ``"diamond"`` (default) – uses :func:`scipy.ndimage.binary_dilation`
               with the default 4-connected cross structuring element, which
-              produces a diamond (L1-metric) footprint.  Equivalent to the
+              produces a diamond (L1-metric) footprint. Equivalent to the
               historic behaviour.
             * ``"circular"`` – uses :func:`scipy.ndimage.distance_transform_edt`
               to compute exact Euclidean distances, giving a true circular
-              (L2-metric) buffer.  This is both more geometrically accurate and
+              (L2-metric) buffer. This is both more geometrically accurate and
               significantly faster for large buffers because it runs in O(pixels)
               regardless of buffer size, whereas the diamond approach scales as
               O(buffer/res × pixels).
@@ -612,7 +627,17 @@ class ExclusionContainer:
         crs : rasterio.CRS/EPSG
             CRS of the raster. Specify this if the raster has invalid crs.
 
+        Raises
+        ------
+        ValueError
+            If ``buffer_geometry`` is not one of 'diamond' or 'circular'.
         """
+        if buffer_geometry not in ("diamond", "circular"):
+            raise ValueError(
+                f"Invalid buffer_geometry: '{buffer_geometry}'. "
+                "Must be one of 'diamond' or 'circular'."
+            )
+
         d: dict[str, Any] = {
             "raster": raster,
             "codes": codes,

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -12,6 +12,7 @@ Created on Wed May  6 15:23:13 2020.
 # IDEAS for tests
 
 import functools
+import pickle
 import warnings
 
 import geopandas as gpd
@@ -648,64 +649,58 @@ def test_plot_shape_availability(ref, raster):
         excluder.plot_shape_availability(shapes)
 
 
-def test_exclusion_container_serialization_backward_compatibility(ref, raster):
-    """Test pickle serialization of ExclusionContainer and backward compatibility with older configurations."""
-    import pickle
+class TestRasterBufferGeometry:
+    """Diamond vs. circular raster buffering: validation, serialization, edge cases."""
 
-    shapes = gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
     res = 0.01
 
-    # 1. Test serialization/deserialization cycle
-    excluder = ExclusionContainer(ref.crs, res=res)
-    excluder.add_raster(raster, buffer=res, buffer_geometry="circular")
+    @pytest.fixture
+    def shapes(self, ref):
+        return gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
 
-    serialized = pickle.dumps(excluder)
-    deserialized = pickle.loads(serialized)
+    def test_serialization_roundtrip_preserves_geometry(self, shapes, raster):
+        excluder = ExclusionContainer(shapes.crs, res=self.res)
+        excluder.add_raster(raster, buffer=self.res, buffer_geometry="circular")
 
-    assert deserialized.rasters[0]["buffer_geometry"] == "circular"
+        restored = pickle.loads(pickle.dumps(excluder))
+        assert restored.rasters[0]["buffer_geometry"] == "circular"
 
-    # 2. Test backward compatibility: remove buffer_geometry to simulate older saved versions
-    del deserialized.rasters[0]["buffer_geometry"]
+    def test_missing_geometry_key_defaults_to_diamond(self, shapes, raster):
+        legacy = ExclusionContainer(shapes.crs, res=self.res)
+        legacy.add_raster(raster, buffer=self.res, buffer_geometry="circular")
+        del legacy.rasters[0]["buffer_geometry"]
 
-    # This should evaluate successfully by defaulting to "diamond" rather than raising a KeyError
-    masked, transform = shape_availability(shapes, deserialized)
-    assert masked.any()
+        diamond = ExclusionContainer(shapes.crs, res=self.res)
+        diamond.add_raster(raster, buffer=self.res, buffer_geometry="diamond")
 
+        masked_legacy, _ = shape_availability(shapes, legacy)
+        masked_diamond, _ = shape_availability(shapes, diamond)
+        assert (masked_legacy == masked_diamond).all()
 
-def test_raster_circular_buffer_correctness(ref, raster):
-    """Test empty/all-False mask behavior and basic correct sizing of circular buffer."""
-    shapes = gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
-    res = 0.01
+    def test_circular_buffer_on_empty_mask_keeps_borders(self, shapes, raster):
+        excluder = ExclusionContainer(shapes.crs, res=self.res)
+        excluder.add_raster(
+            raster, codes=[-1], buffer=self.res * 5, buffer_geometry="circular"
+        )
+        masked, _ = shape_availability(shapes, excluder)
+        assert masked.all()
 
-    # 1. Test empty mask does not exclude borders (boundary effect fix)
-    empty_excluder = ExclusionContainer(ref.crs, res=res)
-    empty_excluder.add_raster(
-        raster, codes=[-1], buffer=res * 5, buffer_geometry="circular"
-    )
-    masked, transform = shape_availability(shapes, empty_excluder)
-    assert masked.all()
+    def test_invalid_geometry_rejected_at_registration(self, shapes, raster):
+        excluder = ExclusionContainer(shapes.crs, res=self.res)
+        with pytest.raises(ValueError, match="Invalid buffer_geometry"):
+            excluder.add_raster(raster, buffer=self.res, buffer_geometry="hexagon")
 
-
-def test_raster_buffer_geometry_validation(ref, raster):
-    """Test that invalid buffer_geometry choices raise a ValueError."""
-    shapes = gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
-    res = 0.01
-    excluder = ExclusionContainer(ref.crs, res=res)
-
-    # Validation at registration time
-    with pytest.raises(ValueError, match="Invalid buffer_geometry"):
-        excluder.add_raster(raster, buffer=res, buffer_geometry="hexagon")
-
-    # Validation at computation time (e.g. if loaded from bad external source / modified manually)
-    excluder.rasters.append({
-        "raster": raster,
-        "codes": None,
-        "buffer": res,
-        "buffer_geometry": "hexagon",
-        "invert": False,
-        "nodata": 255,
-        "allow_no_overlap": False,
-        "crs": None,
-    })
-    with pytest.raises(ValueError, match="Unsupported buffer geometry"):
-        shape_availability(shapes, excluder)
+    def test_invalid_geometry_rejected_at_computation(self, shapes, raster):
+        excluder = ExclusionContainer(shapes.crs, res=self.res)
+        excluder.rasters.append({
+            "raster": raster,
+            "codes": None,
+            "buffer": self.res,
+            "buffer_geometry": "hexagon",
+            "invert": False,
+            "nodata": 255,
+            "allow_no_overlap": False,
+            "crs": None,
+        })
+        with pytest.raises(ValueError, match="Unsupported buffer geometry"):
+            shape_availability(shapes, excluder)

--- a/test/test_gis.py
+++ b/test/test_gis.py
@@ -646,3 +646,66 @@ def test_plot_shape_availability(ref, raster):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         excluder.plot_shape_availability(shapes)
+
+
+def test_exclusion_container_serialization_backward_compatibility(ref, raster):
+    """Test pickle serialization of ExclusionContainer and backward compatibility with older configurations."""
+    import pickle
+
+    shapes = gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
+    res = 0.01
+
+    # 1. Test serialization/deserialization cycle
+    excluder = ExclusionContainer(ref.crs, res=res)
+    excluder.add_raster(raster, buffer=res, buffer_geometry="circular")
+
+    serialized = pickle.dumps(excluder)
+    deserialized = pickle.loads(serialized)
+
+    assert deserialized.rasters[0]["buffer_geometry"] == "circular"
+
+    # 2. Test backward compatibility: remove buffer_geometry to simulate older saved versions
+    del deserialized.rasters[0]["buffer_geometry"]
+
+    # This should evaluate successfully by defaulting to "diamond" rather than raising a KeyError
+    masked, transform = shape_availability(shapes, deserialized)
+    assert masked.any()
+
+
+def test_raster_circular_buffer_correctness(ref, raster):
+    """Test empty/all-False mask behavior and basic correct sizing of circular buffer."""
+    shapes = gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
+    res = 0.01
+
+    # 1. Test empty mask does not exclude borders (boundary effect fix)
+    empty_excluder = ExclusionContainer(ref.crs, res=res)
+    empty_excluder.add_raster(
+        raster, codes=[-1], buffer=res * 5, buffer_geometry="circular"
+    )
+    masked, transform = shape_availability(shapes, empty_excluder)
+    assert masked.all()
+
+
+def test_raster_buffer_geometry_validation(ref, raster):
+    """Test that invalid buffer_geometry choices raise a ValueError."""
+    shapes = gpd.GeoSeries([box(X0, Y0, X1, Y1)], crs=ref.crs)
+    res = 0.01
+    excluder = ExclusionContainer(ref.crs, res=res)
+
+    # Validation at registration time
+    with pytest.raises(ValueError, match="Invalid buffer_geometry"):
+        excluder.add_raster(raster, buffer=res, buffer_geometry="hexagon")
+
+    # Validation at computation time (e.g. if loaded from bad external source / modified manually)
+    excluder.rasters.append({
+        "raster": raster,
+        "codes": None,
+        "buffer": res,
+        "buffer_geometry": "hexagon",
+        "invert": False,
+        "nodata": 255,
+        "allow_no_overlap": False,
+        "crs": None,
+    })
+    with pytest.raises(ValueError, match="Unsupported buffer geometry"):
+        shape_availability(shapes, excluder)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Contributors to atlite <https://github.com/pypsa/atlite>

SPDX-License-Identifier: CC0-1.0
-->


## Changes proposed in this Pull Request
Add `buffer_geometry` argument to `ExclusionContainer.add_raster()`
Previously, the buffer applied to raster exclusions in `shape_availability()` always used scipy.ndimage.binary_dilation which produces a diamond-shaped (L1-metric) buffer: each iteration expands the excluded area by one pixel in the four cardinal directions, so the footprint after N iterations is a diamond of radius N.
This PR adds a `buffer_geometry` parameter to `add_raster()` that lets users choose between two buffer shapes:
	• "diamond" (default) – retains the existing binary_dilation behaviour. No change to existing code that does not pass buffer_geometry.
	• "circular" – uses `scipy.ndimage.distance_transform_edt` to compute exact Euclidean distances. Every pixel whose Euclidean distance to the nearest excluded pixel is ≤ buffer / res is marked as excluded, producing a geometrically accurate circular buffer.

According to Claude, the circular buffer method migth also be faster:
"Performance: The circular method runs in O(pixels) with a single linear-time scan regardless of buffer size. The diamond method runs in O(N × pixels) where N = buffer / res, meaning it becomes proportionally slower as the buffer grows. For typical use cases (e.g. a 500 m buffer at 100 m resolution, N = 5) the circular method is already several times faster, and the gap widens with larger buffers."


## Additional info
I got aware of the raster buffering while testing atlite raster exclusion with buffering. I measured the distance of the buffer in the output raster and the buffer distance was only correct along the grid (vertically and horizontally) but not in diagonal directions.
I used Claude to understand the current raster buffering and to implement the circular buffering. 
Before adding realease notes and add the argument to `add_raster()` in the documentation, please give the PR a review and let me know if it makes sense.

I used the following code in a Jupyter Notebook (separate code cells) to test the results (Let me know if you need the input files to test it)

```python
import atlite
import os
import geopandas as gpd
import matplotlib.pyplot as plt

regionPath = os.path.join("Odense_square_EPSG4326.geojson")
region = gpd.read_file(regionPath)
region = region.to_crs(25832) #local UTM zone
print(region.crs)

# initiate Exclusion container
excluder = atlite.ExclusionContainer(crs=25832, res=10)
# add raster (single pixel) with buffer
excluder.add_raster("single_pixel.tif", codes=1, buffer=500, buffer_geometry="diamond", crs=4326)
masked, transform = excluder.compute_shape_availability(region)
# plot
fig, ax = plt.subplots()
excluder.plot_shape_availability(region)

# initiate Exclusion container
excluder = atlite.ExclusionContainer(crs=25832, res=10)
# add raster (single pixel) with buffer
excluder.add_raster("single_pixel.tif", codes=1, buffer=500, buffer_geometry="circular", crs=4326)
masked, transform = excluder.compute_shape_availability(region)
# plot
fig, ax = plt.subplots()
excluder.plot_shape_availability(region)
```

These are the plots with the different raster buffering methods (there is a single pixel in the center. The buffer is applied around this pixel):

<img width="535" height="433" alt="image" src="https://github.com/user-attachments/assets/df1532fe-958a-46c0-93b3-11f02fddce15" />

<img width="535" height="433" alt="image" src="https://github.com/user-attachments/assets/09475469-0437-44d7-a2dd-321765bf9005" />


## Checklist

- [ ] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [ ] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.
