### PR TITLE
Fix raster exclusions broken by rasterio 1.5.1 nodata perturbation

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,6 +30,10 @@ Upcoming Release
   ``convert_line_rating`` interpreted ``psi`` as degrees. Azimuths are now
   computed in degrees, matching the documented unit.
 
+* Fix raster exclusions being wrongly applied with rasterio 1.5.1, which
+  perturbs source values colliding with the reprojection nodata value. Rasters
+  added with ``nodata=0`` excluded their whole extent.
+
 `v0.6.1 <https://github.com/PyPSA/atlite/releases/tag/v0.6.1>`__ (21st April 2026)
 =======================================================================================
 

--- a/atlite/gis.py
+++ b/atlite/gis.py
@@ -340,14 +340,17 @@ def projected_mask(
         return masked, transform_
 
     assert shape is not None and crs is not None
+    # Pre-fill instead of passing dst_nodata: GDAL perturbs source values which
+    # collide with dst_nodata (e.g. 0) to the smallest representable non-zero value.
+    dest = np.full(shape, nodata, dtype=np.float64)
     return rio.warp.reproject(  # type: ignore[no-any-return]
         masked,
-        empty(shape),
+        dest,
         src_crs=raster.crs,
         dst_crs=crs,
         src_transform=transform_,
         dst_transform=transform,
-        dst_nodata=nodata,
+        init_dest_nodata=False,
     )
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fixes `test_shape_availability_excluder_partial_overlap`, which has been failing on `master` (and therefore on every open PR) since rasterio 1.5.1 was released. It fails on Python 3.12/3.13 and passes on 3.11 only because of which rasterio version gets resolved.

`projected_mask` reprojects the masked raster with `dst_nodata=nodata` into an uninitialised float64 array. rasterio 1.5.1 perturbs these which let's it all collide with `dst_nodata`.

Fix it by pre-filling the destination array with the `nodata` value and pass `init_dest_nodata=False` instead of `dst_nodata`. GDAL leaves untouched cells at the fill value and no longer has a reason to perturb source data. Behaviour is otherwise unchanged (resampling is nearest, so `dst_nodata` had no other effect here).

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable). — existing test already covered this; it was failing.
- [x] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable). — n/a
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [x] I consent to the release of this PR's code under the MIT license.