### PR TITLE
Fix turbine_type search parameter in get_oedb_windturbineconfig

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -35,6 +35,11 @@ Upcoming Release
 
 **Bug fixes**
 
+* Fix ``get_oedb_windturbineconfig`` applying the documented ``turbine_type``
+  search parameter to the value of ``name``. Searching by ``turbine_type``
+  alone raised ``KeyError: 'name'``, and combining it with ``name`` silently
+  ignored the requested turbine type.
+
 * Fix ``Cutout.line_rating`` passing line azimuth in radians while
   ``convert_line_rating`` interpreted ``psi`` as degrees. Azimuths are now
   computed in degrees, matching the documented unit.

--- a/atlite/resource.py
+++ b/atlite/resource.py
@@ -507,7 +507,9 @@ def get_oedb_windturbineconfig(
     if "name" in search_params:
         selector &= df.name.str.contains(search_params["name"], case=False)
     if "turbine_type" in search_params:
-        selector &= df.turbine_type.str.contains(search_params["name"], case=False)
+        selector &= df.turbine_type.str.contains(
+            search_params["turbine_type"], case=False
+        )
     if "manufacturer" in search_params:
         selector &= df.manufacturer.str.contains(
             search_params["manufacturer"], case=False

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -9,9 +9,52 @@ Created on Tue Jun 22 10:46:27 2021.
 @author: fabian
 """
 
+import json
+
+import pandas as pd
 import pytest
 
+from atlite import resource
 from atlite.resource import get_oedb_windturbineconfig, get_windturbineconfig
+
+
+@pytest.fixture
+def oedb_turbines(monkeypatch):
+    """Two-row stand-in for the OEDB library, with 'name' != 'turbine_type'.
+
+    In the live OEDB wind turbine library the two columns hold different
+    strings for most entries, so a filter has to be applied to the column it
+    names. Patching the module-level cache keeps the test offline.
+    """
+    df = pd.DataFrame({
+        "id": [0, 1],
+        "manufacturer": ["Enercon", "Nordex"],
+        "name": ["E-101/3500 E2", "Gamma Series"],
+        "turbine_type": ["E-101/3500", "N131/3600"],
+        "has_power_curve": [True, True],
+        "power_curve_wind_speeds": [json.dumps([0.0, 25.0])] * 2,
+        "power_curve_values": [json.dumps([0.0, 3500.0]), json.dumps([0.0, 3600.0])],
+        "hub_height": [149.0, 134.0],
+        "source": ["test", "test"],
+    })
+    monkeypatch.setattr(resource, "_oedb_turbines", df)
+
+
+def test_oedb_windturbineconfig_turbine_type_alone(oedb_turbines):
+    # 'turbine_type' is a documented search parameter and has to work on its own.
+    assert get_oedb_windturbineconfig(turbine_type="N131/3600")["name"] == "N131/3600"
+
+
+def test_oedb_windturbineconfig_turbine_type_narrows(oedb_turbines):
+    # A 'turbine_type' matching no turbine must narrow the result to nothing,
+    # even when a 'name' that does match is given alongside it.
+    with pytest.raises(RuntimeError, match="No turbine found"):
+        get_oedb_windturbineconfig(name="E-101/3500", turbine_type="N131/3600")
+
+
+def test_oedb_windturbineconfig_manufacturer_search(oedb_turbines):
+    # Control: the neighbouring search parameters keep working.
+    assert get_oedb_windturbineconfig(manufacturer="Nordex")["name"] == "N131/3600"
 
 
 def test_oedb_windturbineconfig():


### PR DESCRIPTION
## Changes proposed in this Pull Request

`get_oedb_windturbineconfig` documents `turbine_type` as a recognized search
argument, but the branch that applies it reads the wrong key:

```python
if "turbine_type" in search_params:
    selector &= df.turbine_type.str.contains(search_params["name"], case=False)
```

Two consequences on current `master`, both reproduced against the live OEDB
`wind_turbine_library` endpoint the function queries:

* `get_oedb_windturbineconfig(turbine_type="E-101/3050")` raises
  `KeyError: 'name'`.
* `get_oedb_windturbineconfig(name="E-101/3050", turbine_type="__nope__")`
  returns `E-101/3050`. The turbine type is silently ignored rather than
  narrowing the search.

The two columns are not interchangeable. Of the 68 library entries that carry
a power curve, 58 have `name != turbine_type`, 51 have a `turbine_type` that
is not a substring of its own `name`, and 7 have no `name` at all (several
Nordex rows), so for those the turbine type is the only string that
identifies them. `manufacturer` and `name` are unaffected and are used as
controls in the new tests.

The fix passes `search_params["turbine_type"]`. Introduced in `12846ce`
(v0.2 preparation, Jan 2021).

The three new tests patch the module-level `_oedb_turbines` cache with a
two-row frame, so they are deterministic and make no network call. Reverting
the fix fails the first two; filtering the right value against the `name`
column fails the first; deleting the branch fails both. `test_resource.py`
previously asserted only that a result was truthy and never passed
`turbine_type=`, which is why the defect survived.

Test suite: 83 passed / 38 skipped on `master` → 86 / 38 with this branch,
the +3 being exactly the new tests. The 38 skips are the CDS-credentialed
cutout tests and are skipped identically either way, so that path is unverified
here. `ruff check` and `ruff format --check` are
clean across the repo.

Written with AI assistance; the behaviour above was measured, not inferred.

## Checklist

- [x] Code changes are sufficiently documented; i.e. new functions contain docstrings and further explanations may be given in `doc`.
- [x] Unit tests for new features were added (if applicable).
- [ ] Newly introduced dependencies are added to `environment.yaml`, `environment_docs.yaml` and `setup.py` (if applicable).
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included.
- [ ] I consent to the release of this PR's code under the MIT license.
